### PR TITLE
More idiomatic Rust

### DIFF
--- a/Arkworks/src/fk20_proofs.rs
+++ b/Arkworks/src/fk20_proofs.rs
@@ -3,7 +3,7 @@ use crate::kzg_proofs::{FFTSettings, KZGSettings};
 use crate::kzg_types::{ArkG1, ArkG2, FsFr as BlstFr};
 use crate::utils::PolyData;
 use kzg::{
-    FFTFr, FK20MultiSettings, FK20SingleSettings, Fr, G1Mul, KZGSettings as KZGST, Poly, FFTG1, G1,
+    FFTFr, FK20MultiSettings, FK20SingleSettings, Fr, G1Mul, Poly, FFTG1, G1,
 };
 // use chrono::Utc;
 
@@ -11,7 +11,7 @@ use kzg::{
 use rayon::prelude::*;
 
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct KzgFK20SingleSettings {
     pub ks: KZGSettings,
     pub x_ext_fft: Vec<ArkG1>,
@@ -19,7 +19,7 @@ pub struct KzgFK20SingleSettings {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct KzgFK20MultiSettings {
     pub ks: KZGSettings,
     pub chunk_len: usize,
@@ -45,14 +45,6 @@ where
 impl FK20SingleSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings>
     for KzgFK20SingleSettings
 {
-    fn default() -> Self {
-        Self {
-            ks: KZGSettings::default(),
-            x_ext_fft: Vec::new(),
-            x_ext_fft_len: 0,
-        }
-    }
-
     fn new(ks: &KZGSettings, n2: usize) -> Result<Self, String> {
         let n = n2 / 2;
 
@@ -74,8 +66,10 @@ impl FK20SingleSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings
         }
         x.push(G1_IDENTITY);
 
-        let mut new_ks = KZGSettings::default();
-        new_ks.fs = ks.fs.clone();
+        let new_ks = KZGSettings {
+            fs: ks.fs.clone(),
+            ..KZGSettings::default()
+        };
 
         Ok(KzgFK20SingleSettings {
             ks: new_ks,
@@ -110,15 +104,6 @@ impl FK20SingleSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings
 impl FK20MultiSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings>
     for KzgFK20MultiSettings
 {
-    fn default() -> Self {
-        Self {
-            ks: KZGSettings::default(),
-            chunk_len: 0,
-            x_ext_fft_files: Vec::new(),
-            length: 0,
-        }
-    }
-
     fn new(ks: &KZGSettings, n2: usize, chunk_len: usize) -> Result<Self, String> {
         // let start_time = Utc::now().time();
         // println!("New begins at {}", start_time);
@@ -173,8 +158,10 @@ impl FK20MultiSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings>
         }
 
         // let start_time = Utc::now().time();
-        let mut new_ks = KZGSettings::default();
-        new_ks.fs = ks.fs.clone();
+        let new_ks = KZGSettings {
+            fs: ks.fs.clone(),
+            ..KZGSettings::default()
+        };
         // let end_time = Utc::now().time();
         // println!("Total time taken to clone stuff is {} and {} ", start_time, end_time);
 

--- a/Arkworks/src/kzg_proofs.rs
+++ b/Arkworks/src/kzg_proofs.rs
@@ -31,7 +31,7 @@ use ark_ec::{
 use ark_ff::{BigInteger256, PrimeField};
 use ark_poly::univariate::DensePolynomial as DensePoly;
 use blst::{blst_fp, blst_fp2};
-use kzg::{FFTFr, FFTSettings as FFTTrait, Fr as FrTrait, KZGSettings as KZGST, Poly};
+use kzg::{FFTFr, Fr as FrTrait, Poly};
 use rand::rngs::StdRng;
 use std::collections::BTreeMap;
 use std::ops::{MulAssign, Neg};
@@ -273,7 +273,7 @@ fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInt> {
     coeffs
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FFTSettings {
     pub max_width: usize,
     pub root_of_unity: BlstFr,
@@ -323,7 +323,7 @@ impl FFTSettings {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KZGSettings {
     pub fs: FFTSettings,
     pub secret_g1: Vec<ArkG1>,
@@ -334,15 +334,17 @@ pub struct KZGSettings {
     pub rand2: Randomness<Fr, UniPoly_381>,
 }
 
-pub fn default_kzg() -> KZGSettings {
-    KZGSettings {
-        fs: FFTSettings::default(),
-        secret_g1: Vec::new(),
-        secret_g2: Vec::new(),
-        length: 0,
-        params: KZG_Bls12_381::setup(1, false, &mut test_rng()).unwrap(),
-        rand: test_rng(),
-        rand2: Randomness::empty(),
+impl Default for KZGSettings {
+    fn default() -> Self {
+        Self {
+            fs: FFTSettings::default(),
+            secret_g1: Vec::new(),
+            secret_g2: Vec::new(),
+            length: 0,
+            params: KZG_Bls12_381::setup(1, false, &mut test_rng()).unwrap(),
+            rand: test_rng(),
+            rand2: Randomness::empty(),
+        }
     }
 }
 

--- a/Arkworks/src/utils.rs
+++ b/Arkworks/src/utils.rs
@@ -9,7 +9,7 @@ use ark_poly::UVPolynomial;
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct PolyData {
     pub coeffs: Vec<BlstFr>,
 }

--- a/blst-from-scratch/src/recovery.rs
+++ b/blst-from-scratch/src/recovery.rs
@@ -1,4 +1,4 @@
-use kzg::{FFTFr, Fr, Poly, ZeroPoly};
+use kzg::{FFTFr, Fr, ZeroPoly};
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
@@ -85,8 +85,9 @@ pub fn recover_poly_from_samples(
         }
     }
     // Now inverse FFT so that poly_with_zero is (E * Z_r,I)(x) = (D * Z_r,I)(x)
-    let mut poly_with_zero: FsPoly = FsPoly::default();
-    poly_with_zero.coeffs = fs.fft_fr(&poly_evaluations_with_zero.coeffs, true).unwrap();
+    let mut poly_with_zero = FsPoly {
+        coeffs: fs.fft_fr(&poly_evaluations_with_zero.coeffs, true).unwrap(),
+    };
 
     // x -> k * x
     let len_zero_poly = zero_poly.coeffs.len();
@@ -141,8 +142,9 @@ pub fn recover_poly_from_samples(
         eval_scaled_zero_poly = fs.fft_fr(&scaled_zero_poly, false).unwrap();
     }
 
-    let mut eval_scaled_reconstructed_poly = FsPoly::default();
-    eval_scaled_reconstructed_poly.coeffs = eval_scaled_poly_with_zero.clone();
+    let mut eval_scaled_reconstructed_poly = FsPoly {
+        coeffs: eval_scaled_poly_with_zero.clone(),
+    };
     for i in 0..len_samples {
         eval_scaled_reconstructed_poly.coeffs[i] = eval_scaled_poly_with_zero[i]
             .div(&eval_scaled_zero_poly[i])

--- a/blst-from-scratch/src/types/fft_settings.rs
+++ b/blst-from-scratch/src/types/fft_settings.rs
@@ -3,6 +3,7 @@ use kzg::{FFTSettings, Fr};
 use crate::consts::SCALE2_ROOT_OF_UNITY;
 use crate::types::fr::FsFr;
 
+#[derive(Debug, Clone)]
 pub struct FsFFTSettings {
     pub max_width: usize,
     pub root_of_unity: FsFr,
@@ -10,11 +11,13 @@ pub struct FsFFTSettings {
     pub reverse_roots_of_unity: Vec<FsFr>,
 }
 
-impl FFTSettings<FsFr> for FsFFTSettings {
+impl Default for FsFFTSettings {
     fn default() -> Self {
         Self::new(0).unwrap()
     }
+}
 
+impl FFTSettings<FsFr> for FsFFTSettings {
     /// Create FFTSettings with roots of unity for a selected scale. Resulting roots will have a magnitude of 2 ^ max_scale.
     fn new(scale: usize) -> Result<FsFFTSettings, String> {
         if scale >= SCALE2_ROOT_OF_UNITY.len() {
@@ -58,17 +61,6 @@ impl FFTSettings<FsFr> for FsFFTSettings {
 
     fn get_reversed_roots_of_unity(&self) -> &[FsFr] {
         &self.reverse_roots_of_unity
-    }
-}
-
-impl Clone for FsFFTSettings {
-    fn clone(&self) -> Self {
-        let mut output = FsFFTSettings::new(0).unwrap();
-        output.max_width = self.max_width;
-        output.root_of_unity = self.root_of_unity;
-        output.expanded_roots_of_unity = self.expanded_roots_of_unity.clone();
-        output.reverse_roots_of_unity = self.reverse_roots_of_unity.clone();
-        output
     }
 }
 

--- a/blst-from-scratch/src/types/fk20_multi_settings.rs
+++ b/blst-from-scratch/src/types/fk20_multi_settings.rs
@@ -1,4 +1,4 @@
-use kzg::{FK20MultiSettings, KZGSettings, Poly, FFTG1, G1};
+use kzg::{FK20MultiSettings, Poly, FFTG1, G1};
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
@@ -24,9 +24,7 @@ impl Clone for FsFK20MultiSettings {
     }
 }
 
-impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
-    for FsFK20MultiSettings
-{
+impl Default for FsFK20MultiSettings {
     fn default() -> Self {
         Self {
             kzg_settings: FsKZGSettings::default(),
@@ -34,7 +32,11 @@ impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             x_ext_fft_files: vec![],
         }
     }
+}
 
+impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
+    for FsFK20MultiSettings
+{
     #[allow(clippy::many_single_char_names)]
     fn new(ks: &FsKZGSettings, n2: usize, chunk_len: usize) -> Result<Self, String> {
         if n2 > ks.fs.max_width {

--- a/blst-from-scratch/src/types/fk20_single_settings.rs
+++ b/blst-from-scratch/src/types/fk20_single_settings.rs
@@ -1,4 +1,4 @@
-use kzg::{FK20SingleSettings, KZGSettings, Poly, FFTG1, G1};
+use kzg::{FK20SingleSettings, Poly, FFTG1, G1};
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
@@ -8,30 +8,15 @@ use crate::types::kzg_settings::FsKZGSettings;
 use crate::types::poly::FsPoly;
 use crate::utils::{is_power_of_two, reverse_bit_order};
 
+#[derive(Debug, Clone, Default)]
 pub struct FsFK20SingleSettings {
     pub kzg_settings: FsKZGSettings,
     pub x_ext_fft: Vec<FsG1>,
 }
 
-impl Clone for FsFK20SingleSettings {
-    fn clone(&self) -> Self {
-        Self {
-            kzg_settings: self.kzg_settings.clone(),
-            x_ext_fft: self.x_ext_fft.clone(),
-        }
-    }
-}
-
 impl FK20SingleSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
     for FsFK20SingleSettings
 {
-    fn default() -> Self {
-        Self {
-            kzg_settings: FsKZGSettings::default(),
-            x_ext_fft: vec![],
-        }
-    }
-
     fn new(kzg_settings: &FsKZGSettings, n2: usize) -> Result<Self, String> {
         let n = n2 / 2;
 

--- a/blst-from-scratch/src/types/fr.rs
+++ b/blst-from-scratch/src/types/fr.rs
@@ -5,14 +5,10 @@ use blst::{
 };
 use kzg::Fr;
 
-#[derive(Debug)]
-pub struct FsFr(pub blst::blst_fr);
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub struct FsFr(pub blst_fr);
 
 impl Fr for FsFr {
-    fn default() -> Self {
-        Self(blst_fr::default())
-    }
-
     fn null() -> Self {
         Self::from_u64_arr(&[u64::MAX, u64::MAX, u64::MAX, u64::MAX])
     }
@@ -199,7 +195,7 @@ impl FsFr {
 
     pub fn from_scalar(scalar: [u8; 32usize]) -> Result<Self, u8> {
         let mut bls_scalar = blst_scalar::default();
-        
+
         let mut fr = blst_fr::default();
         unsafe {
             blst_scalar_from_lendian(& mut bls_scalar, scalar.as_ptr());
@@ -209,9 +205,7 @@ impl FsFr {
             }
             blst_fr_from_scalar(&mut fr, &bls_scalar);
         }
-        let mut ret = Self::default();
-        ret.0 = fr;
-        Ok(ret)
+        Ok(Self(fr))
     }
 
     pub fn hash_to_bls_field(scalar: [u8; 32usize]) -> Self {
@@ -220,16 +214,6 @@ impl FsFr {
         unsafe {
             blst_fr_from_scalar(&mut fr, &bls_scalar);
         }
-        let mut ret = Self::default();
-        ret.0 = fr;
-        ret
+        Self(fr)
     }
 }
-
-impl Clone for FsFr {
-    fn clone(&self) -> Self {
-        FsFr(self.0)
-    }
-}
-
-impl Copy for FsFr {}

--- a/blst-from-scratch/src/types/g1.rs
+++ b/blst-from-scratch/src/types/g1.rs
@@ -9,8 +9,8 @@ use crate::types::fr::FsFr;
 use crate::utils::log_2_byte;
 
 #[repr(C)]
-#[derive(Debug)]
-pub struct FsG1(pub blst::blst_p1);
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct FsG1(pub blst_p1);
 
 impl FsG1 {
     pub(crate) const fn from_xyz(x: blst_fp, y: blst_fp, z: blst_fp) -> Self {
@@ -74,14 +74,6 @@ impl G1 for FsG1 {
         unsafe { blst_p1_is_equal(&self.0, &b.0) }
     }
 }
-
-impl Clone for FsG1 {
-    fn clone(&self) -> Self {
-        FsG1(self.0)
-    }
-}
-
-impl Copy for FsG1 {}
 
 impl G1Mul<FsFr> for FsG1 {
     fn mul(&self, b: &FsFr) -> Self {

--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -7,7 +7,8 @@ use kzg::{G2Mul, G2};
 use crate::consts::{G2_GENERATOR, G2_NEGATIVE_GENERATOR};
 use crate::types::fr::FsFr;
 
-pub struct FsG2(pub blst::blst_p2);
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct FsG2(pub blst_p2);
 
 impl G2Mul<FsFr> for FsG2 {
     fn mul(&self, b: &FsFr) -> Self {
@@ -79,11 +80,3 @@ impl FsG2 {
         Self(blst_p2::default())
     }
 }
-
-impl Clone for FsG2 {
-    fn clone(&self) -> Self {
-        FsG2(self.0)
-    }
-}
-
-impl Copy for FsG2 {}

--- a/blst-from-scratch/src/types/kzg_settings.rs
+++ b/blst-from-scratch/src/types/kzg_settings.rs
@@ -9,6 +9,7 @@ use crate::types::g2::FsG2;
 use crate::types::poly::FsPoly;
 use crate::utils::is_power_of_two;
 
+#[derive(Debug, Clone, Default)]
 pub struct FsKZGSettings {
     pub fs: FsFFTSettings,
     // Both secret_g1 and secret_g2 have the same number of elements
@@ -16,25 +17,7 @@ pub struct FsKZGSettings {
     pub secret_g2: Vec<FsG2>,
 }
 
-impl Clone for FsKZGSettings {
-    fn clone(&self) -> Self {
-        Self {
-            fs: self.fs.clone(),
-            secret_g1: self.secret_g1.clone(),
-            secret_g2: self.secret_g2.clone(),
-        }
-    }
-}
-
 impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly> for FsKZGSettings {
-    fn default() -> Self {
-        Self {
-            secret_g1: Vec::new(),
-            secret_g2: Vec::new(),
-            fs: FsFFTSettings::default(),
-        }
-    }
-
     fn new(
         secret_g1: &[FsG1],
         secret_g2: &[FsG2],

--- a/blst-from-scratch/src/types/poly.rs
+++ b/blst-from-scratch/src/types/poly.rs
@@ -7,16 +7,12 @@ use crate::types::fr::FsFr;
 use crate::utils::is_power_of_two;
 use crate::utils::{log2_pow2, log2_u64, min_u64, next_power_of_two};
 
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct FsPoly {
     pub coeffs: Vec<FsFr>,
 }
 
 impl Poly<FsFr> for FsPoly {
-    fn default() -> Self {
-        // Not perfect, but shouldn't fail
-        Self::new(0).unwrap()
-    }
-
     fn new(size: usize) -> Result<Self, String> {
         Ok(Self {
             coeffs: vec![FsFr::default(); size],
@@ -387,14 +383,6 @@ impl FsPoly {
     }
 }
 
-impl Clone for FsPoly {
-    fn clone(&self) -> Self {
-        FsPoly {
-            coeffs: self.coeffs.clone(),
-        }
-    }
-}
-
 impl PolyRecover<FsFr, FsPoly, FsFFTSettings> for FsPoly {
     fn recover_poly_from_samples(
         samples: &[Option<FsFr>],
@@ -438,8 +426,9 @@ impl PolyRecover<FsFr, FsPoly, FsFFTSettings> for FsPoly {
             }
         }
         // Now inverse FFT so that poly_with_zero is (E * Z_r,I)(x) = (D * Z_r,I)(x)
-        let mut poly_with_zero: FsPoly = FsPoly::default();
-        poly_with_zero.coeffs = fs.fft_fr(&poly_evaluations_with_zero.coeffs, true).unwrap();
+        let mut poly_with_zero = FsPoly {
+            coeffs: fs.fft_fr(&poly_evaluations_with_zero.coeffs, true).unwrap(),
+        };
 
         // x -> k * x
         let len_zero_poly = zero_poly.coeffs.len();
@@ -457,8 +446,9 @@ impl PolyRecover<FsFr, FsPoly, FsFFTSettings> for FsPoly {
             fs.fft_fr(&scaled_poly_with_zero, false).unwrap();
         let eval_scaled_zero_poly: Vec<FsFr> = fs.fft_fr(&scaled_zero_poly, false).unwrap();
 
-        let mut eval_scaled_reconstructed_poly = FsPoly::default();
-        eval_scaled_reconstructed_poly.coeffs = eval_scaled_poly_with_zero.clone();
+        let mut eval_scaled_reconstructed_poly = FsPoly {
+            coeffs: eval_scaled_poly_with_zero.clone(),
+        };
         for i in 0..len_samples {
             eval_scaled_reconstructed_poly.coeffs[i] = eval_scaled_poly_with_zero[i]
                 .div(&eval_scaled_zero_poly[i])

--- a/blst-from-scratch/src/zero_poly.rs
+++ b/blst-from-scratch/src/zero_poly.rs
@@ -8,8 +8,6 @@ use crate::types::poly::FsPoly;
 use crate::utils::{is_power_of_two, next_power_of_two};
 
 #[cfg(feature = "parallel")]
-use kzg::Poly;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 #[allow(dead_code)]

--- a/ckzg/src/eip_4844.rs
+++ b/ckzg/src/eip_4844.rs
@@ -8,7 +8,7 @@ use crate::kzgsettings4844::KzgKZGSettings4844;
 // use crate::utils::reverse_bit_order;
 
 use kzg::eip_4844::{Blob, KZGCommitment, KZGProof};
-use kzg::{Fr, KZGSettings};
+use kzg::Fr;
 use libc::{fdopen, FILE};
 use std::ffi::CStr;
 use std::os::unix::io::IntoRawFd;

--- a/ckzg/src/fftsettings4844.rs
+++ b/ckzg/src/fftsettings4844.rs
@@ -1,5 +1,5 @@
 use crate::finite::BlstFr;
-use kzg::{FFTSettings, Fr};
+use kzg::FFTSettings;
 use std::slice;
 
 #[repr(C)]
@@ -13,16 +13,18 @@ pub struct KzgFFTSettings4844 {
 
 extern "C" {}
 
-impl FFTSettings<BlstFr> for KzgFFTSettings4844 {
+impl Default for KzgFFTSettings4844 {
     fn default() -> Self {
         Self {
             max_width: 0,
-            expanded_roots_of_unity: &mut Fr::default(),
-            reverse_roots_of_unity: &mut Fr::default(),
-            roots_of_unity: &mut Fr::default(),
+            expanded_roots_of_unity: &mut BlstFr::default(),
+            reverse_roots_of_unity: &mut BlstFr::default(),
+            roots_of_unity: &mut BlstFr::default(),
         }
     }
+}
 
+impl FFTSettings<BlstFr> for KzgFFTSettings4844 {
     // underscore was added to avoid warnings when new is unused
     fn new(_scale: usize) -> Result<Self, String> {
         todo!();

--- a/ckzg/src/finite.rs
+++ b/ckzg/src/finite.rs
@@ -70,16 +70,12 @@ extern "C" {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct BlstFr {
     pub l: [u64; 4],
 }
 
 impl Fr for BlstFr {
-    fn default() -> Self {
-        Self { l: [0; 4] }
-    }
-
     fn null() -> Self {
         Self { l: [u64::MAX; 4] }
     }
@@ -93,7 +89,7 @@ impl Fr for BlstFr {
     }
 
     fn rand() -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         let mut rng = thread_rng();
         let a: [u64; 4] = [
             rng.next_u64(),
@@ -108,7 +104,7 @@ impl Fr for BlstFr {
     }
 
     fn from_u64_arr(u: &[u64; 4]) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             fr_from_uint64s(&mut ret, u.as_ptr());
         }
@@ -116,7 +112,7 @@ impl Fr for BlstFr {
     }
 
     fn from_u64(u: u64) -> Self {
-        let mut fr = Fr::default();
+        let mut fr = Self::default();
         unsafe {
             fr_from_uint64(&mut fr, u);
         }
@@ -144,7 +140,7 @@ impl Fr for BlstFr {
     }
 
     fn sqr(&self) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             blst_fr_sqr(&mut ret, self);
         }
@@ -152,7 +148,7 @@ impl Fr for BlstFr {
     }
 
     fn mul(&self, b: &Self) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             blst_fr_mul(&mut ret, self, b);
         }
@@ -160,7 +156,7 @@ impl Fr for BlstFr {
     }
 
     fn add(&self, b: &Self) -> Self {
-        let mut sum = Fr::default();
+        let mut sum = Self::default();
         unsafe {
             blst_fr_add(&mut sum, self, b);
         }
@@ -168,7 +164,7 @@ impl Fr for BlstFr {
     }
 
     fn sub(&self, b: &Self) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             blst_fr_sub(&mut ret, self, b);
         }
@@ -176,7 +172,7 @@ impl Fr for BlstFr {
     }
 
     fn eucl_inverse(&self) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             blst_fr_eucl_inverse(&mut ret, self);
         }
@@ -185,7 +181,7 @@ impl Fr for BlstFr {
     }
 
     fn negate(&self) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             // man rodos, kad tokios nera
             fr_negate(&mut ret, self);
@@ -194,7 +190,7 @@ impl Fr for BlstFr {
     }
 
     fn inverse(&self) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             blst_fr_inverse(&mut ret, self);
         }
@@ -203,7 +199,7 @@ impl Fr for BlstFr {
     }
 
     fn pow(&self, n: usize) -> Self {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             fr_pow(&mut ret, self, n as u64);
         }
@@ -211,7 +207,7 @@ impl Fr for BlstFr {
     }
 
     fn div(&self, b: &Self) -> Result<Self, String> {
-        let mut ret = Fr::default();
+        let mut ret = Self::default();
         unsafe {
             fr_div(&mut ret, self, b);
         }

--- a/ckzg/src/fk20settings.rs
+++ b/ckzg/src/fk20settings.rs
@@ -1,4 +1,4 @@
-use kzg::{FK20MultiSettings, FK20SingleSettings, KZGSettings, Poly, G1};
+use kzg::{FK20MultiSettings, FK20SingleSettings, Poly, G1};
 
 use crate::consts::{BlstP1, BlstP2, KzgRet};
 use crate::fftsettings::KzgFFTSettings;
@@ -66,19 +66,21 @@ pub struct KzgFK20MultiSettings {
     pub length: u64,
 }
 
-impl FK20SingleSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGSettings>
-    for KzgFK20SingleSettings
-{
+impl Default for KzgFK20SingleSettings {
     fn default() -> Self {
         Self {
-            ks: &KZGSettings::default(),
+            ks: &KzgKZGSettings::default(),
             x_ext_fft: &mut G1::default(),
             x_ext_fft_len: 0,
         }
     }
+}
 
+impl FK20SingleSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGSettings>
+    for KzgFK20SingleSettings
+{
     fn new(ks: &KzgKZGSettings, n2: usize) -> Result<Self, String> {
-        let mut settings = FK20SingleSettings::default();
+        let mut settings = Self::default();
         unsafe {
             match new_fk20_single_settings(&mut settings, n2 as u64, ks) {
                 KzgRet::KzgOk => Ok(settings),
@@ -124,20 +126,22 @@ impl Drop for KzgFK20SingleSettings {
     }
 }
 
-impl FK20MultiSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGSettings>
-    for KzgFK20MultiSettings
-{
+impl Default for KzgFK20MultiSettings {
     fn default() -> Self {
         Self {
-            ks: &KZGSettings::default(),
+            ks: &KzgKZGSettings::default(),
             chunk_len: 0,
             x_ext_fft_files: std::ptr::null_mut(),
             length: 0,
         }
     }
+}
 
+impl FK20MultiSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGSettings>
+    for KzgFK20MultiSettings
+{
     fn new(ks: &KzgKZGSettings, n2: usize, chunk_len: usize) -> Result<Self, String> {
-        let mut settings = FK20MultiSettings::default();
+        let mut settings = Self::default();
         unsafe {
             match new_fk20_multi_settings(&mut settings, n2 as u64, chunk_len as u64, ks) {
                 KzgRet::KzgOk => Ok(settings),

--- a/ckzg/src/kzgsettings.rs
+++ b/ckzg/src/kzgsettings.rs
@@ -78,22 +78,13 @@ impl Default for KzgKZGSettings {
 }
 
 impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly> for KzgKZGSettings {
-    fn default() -> Self {
-        Self {
-            fs: &FFTSettings::default(),
-            secret_g1: &mut G1::default(),
-            secret_g2: &mut G2::default(),
-            length: 0,
-        }
-    }
-
     fn new(
         secret_g1: &[BlstP1],
         secret_g2: &[BlstP2],
         length: usize,
         fs: &KzgFFTSettings,
     ) -> Result<Self, String> {
-        let mut settings = KZGSettings::default();
+        let mut settings = Self::default();
         unsafe {
             match new_kzg_settings(
                 &mut settings,
@@ -218,7 +209,7 @@ pub fn generate_trusted_setup(len: usize, secret: [u8; 32usize]) -> (Vec<BlstP1>
     blst_scalar.b[..secret.len()].clone_from_slice(&secret[..]);
 
     let mut s_pow: BlstFr = Fr::one();
-    let mut s = Fr::default();
+    let mut s = BlstFr::default();
     unsafe { fr_from_scalar(&mut s, &blst_scalar) };
 
     let mut s1 = vec![G1::default(); 0];

--- a/ckzg/src/kzgsettings4844.rs
+++ b/ckzg/src/kzgsettings4844.rs
@@ -24,15 +24,17 @@ extern "C" {
     fn free_trusted_setup(s: *mut KzgKZGSettings4844);
 }
 
-impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings4844, KzgPoly> for KzgKZGSettings4844 {
+impl Default for KzgKZGSettings4844 {
     fn default() -> Self {
         Self {
-            fs: &FFTSettings::default(),
+            fs: &KzgFFTSettings4844::default(),
             g1_values: &mut G1::default(),
             g2_values: &mut G2::default(),
         }
     }
+}
 
+impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings4844, KzgPoly> for KzgKZGSettings4844 {
     // underscore was added to avoid warnings when new is unused
     fn new(
         _secret_g1: &[BlstP1],

--- a/ckzg/src/poly.rs
+++ b/ckzg/src/poly.rs
@@ -44,16 +44,18 @@ pub struct KzgPoly {
     pub length: u64,
 }
 
-impl Poly<BlstFr> for KzgPoly {
+impl Default for KzgPoly {
     fn default() -> Self {
         Self {
-            coeffs: &mut Fr::default(),
+            coeffs: &mut BlstFr::default(),
             length: 0,
         }
     }
+}
 
+impl Poly<BlstFr> for KzgPoly {
     fn new(size: usize) -> Result<Self, String> {
-        let mut poly = Poly::default();
+        let mut poly = Self::default();
         unsafe {
             match new_poly(&mut poly, size as u64) {
                 KzgRet::KzgOk => Ok(poly),
@@ -81,7 +83,7 @@ impl Poly<BlstFr> for KzgPoly {
     }
 
     fn eval(&self, x: &BlstFr) -> BlstFr {
-        let mut out = Fr::default();
+        let mut out = BlstFr::default();
         unsafe {
             eval_poly(&mut out, self, x);
         }
@@ -110,7 +112,7 @@ impl Poly<BlstFr> for KzgPoly {
     }
 
     fn div(&mut self, x: &Self) -> Result<Self, String> {
-        let mut poly = Poly::default();
+        let mut poly = Self::default();
         unsafe {
             match new_poly_div(&mut poly, self, x) {
                 KzgRet::KzgOk => Ok(poly),
@@ -120,7 +122,7 @@ impl Poly<BlstFr> for KzgPoly {
     }
 
     fn long_div(&mut self, x: &Self) -> Result<Self, String> {
-        let mut poly = Poly::new(self.len()).unwrap();
+        let mut poly = Self::new(self.len()).unwrap();
         unsafe {
             match poly_long_div(&mut poly, self, x) {
                 KzgRet::KzgOk => Ok(poly),
@@ -133,7 +135,7 @@ impl Poly<BlstFr> for KzgPoly {
     }
 
     fn fast_div(&mut self, x: &Self) -> Result<Self, String> {
-        let mut poly = Poly::new(self.len()).unwrap();
+        let mut poly = Self::new(self.len()).unwrap();
         unsafe {
             match poly_fast_div(&mut poly, self, x) {
                 KzgRet::KzgOk => Ok(poly),
@@ -146,7 +148,7 @@ impl Poly<BlstFr> for KzgPoly {
     }
 
     fn mul_direct(&mut self, x: &Self, len: usize) -> Result<Self, String> {
-        let mut poly = Poly::new(len).unwrap();
+        let mut poly = Self::new(len).unwrap();
         unsafe {
             match poly_mul(&mut poly, self, x, RUN_PARALLEL) {
                 KzgRet::KzgOk => Ok(poly),
@@ -172,7 +174,7 @@ impl PolyRecover<BlstFr, KzgPoly, KzgFFTSettings> for KzgPoly {
         samples: &[Option<BlstFr>],
         fs: &KzgFFTSettings,
     ) -> Result<KzgPoly, String> {
-        let mut reconstructed_data = vec![Fr::default(); samples.len()];
+        let mut reconstructed_data = vec![BlstFr::default(); samples.len()];
         let mut optionless_samples = Vec::new();
         for s in samples {
             if s.is_some() {

--- a/kzg-bench/src/tests/fk20_proofs.rs
+++ b/kzg-bench/src/tests/fk20_proofs.rs
@@ -234,8 +234,8 @@ fn fk_multi_case<
     reverse_bit_order(&mut extended_coeffs_fft);
 
     // Verify the proofs
-    let mut ys = vec![Fr::default(); chunk_len];
-    let mut ys2 = vec![Fr::default(); chunk_len];
+    let mut ys = vec![TFr::default(); chunk_len];
+    let mut ys2 = vec![TFr::default(); chunk_len];
     let domain_stride = fs.get_max_width() / (2 * n);
     for pos in 0..(2 * chunk_count) {
         let domain_pos = reverse_bits_limited(chunk_count, pos);

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -1,8 +1,6 @@
 pub mod eip_4844;
 
-pub trait Fr: Clone {
-    fn default() -> Self;
-
+pub trait Fr: Default + Clone {
     fn null() -> Self;
 
     fn zero() -> Self;
@@ -119,9 +117,7 @@ pub trait ZeroPoly<Coeff: Fr, Polynomial: Poly<Coeff>> {
     ) -> Result<(Vec<Coeff>, Polynomial), String>;
 }
 
-pub trait FFTSettings<Coeff: Fr>: Clone {
-    fn default() -> Self;
-
+pub trait FFTSettings<Coeff: Fr>: Default + Clone {
     fn new(scale: usize) -> Result<Self, String>;
 
     fn get_max_width(&self) -> usize;
@@ -144,9 +140,7 @@ pub trait FFTSettingsPoly<Coeff: Fr, Polynomial: Poly<Coeff>, FSettings: FFTSett
     ) -> Result<Polynomial, String>;
 }
 
-pub trait Poly<Coeff: Fr>: Clone {
-    fn default() -> Self;
-
+pub trait Poly<Coeff: Fr>: Default + Clone {
     fn new(size: usize) -> Result<Self, String>;
 
     fn get_coeff_at(&self, i: usize) -> Coeff;
@@ -188,10 +182,8 @@ pub trait KZGSettings<
     Coeff3: G2,
     Fs: FFTSettings<Coeff1>,
     Polynomial: Poly<Coeff1>,
->: Clone
+>: Default + Clone
 {
-    fn default() -> Self;
-
     fn new(
         secret_g1: &[Coeff2],
         secret_g2: &[Coeff3],
@@ -232,10 +224,8 @@ pub trait FK20SingleSettings<
     Fs: FFTSettings<Coeff1>,
     Polynomial: Poly<Coeff1>,
     Ks: KZGSettings<Coeff1, Coeff2, Coeff3, Fs, Polynomial>,
->: Clone
+>: Default + Clone
 {
-    fn default() -> Self;
-
     fn new(ks: &Ks, n2: usize) -> Result<Self, String>;
 
     fn data_availability(&self, p: &Polynomial) -> Result<Vec<Coeff2>, String>;
@@ -250,10 +240,8 @@ pub trait FK20MultiSettings<
     Fs: FFTSettings<Coeff1>,
     Polynomial: Poly<Coeff1>,
     Ks: KZGSettings<Coeff1, Coeff2, Coeff3, Fs, Polynomial>,
->: Clone
+>: Default + Clone
 {
-    fn default() -> Self;
-
     fn new(ks: &Ks, n2: usize, chunk_len: usize) -> Result<Self, String>;
 
     fn data_availability(&self, p: &Polynomial) -> Result<Vec<Coeff2>, String>;

--- a/mcl/kzg/src/data_types/fp2.rs
+++ b/mcl/kzg/src/data_types/fp2.rs
@@ -31,7 +31,7 @@ extern "C" {
     fn mclBnFp2_squareRoot(y: *mut Fp2, x: *const Fp2) -> i32;
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 #[repr(C)]
 pub struct Fp2 {
     pub d: [Fp; 2],

--- a/mcl/kzg/src/data_types/fr.rs
+++ b/mcl/kzg/src/data_types/fr.rs
@@ -93,13 +93,13 @@ impl Fr {
         assert!(fr.get_little_endian(&mut buf));
         buf
     }
-    
+
     pub fn to_u64_arr(&self) -> [u64; 4] {
         use std::convert::TryInto;
         let v: Vec<u64> = Fr::to_scalar(self).chunks(8).map(|ch|{
             u64::from_le_bytes(ch.try_into().unwrap())
         }).collect();
-    
+
         v.try_into().unwrap()
     }
 }

--- a/mcl/kzg/src/data_types/g2.rs
+++ b/mcl/kzg/src/data_types/g2.rs
@@ -30,7 +30,7 @@ extern "C" {
     fn mclBnG2_hashAndMapTo(x: *mut G2, buf: *const u8, bufSize: usize) -> c_int;
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 #[repr(C)]
 pub struct G2 {
     pub x: Fp2,
@@ -61,14 +61,14 @@ impl G2 {
             d: [Fp {
                 d: [0xf5f28fa202940a10, 0xb3f5fb2687b4961a, 0xa1a893b53e2ae580, 0x9894999d1a3caee9, 0x6f67b7631863366b, 0x058191924350bcd7],
             }, Fp {
-                d: [0xa5a9c0759e23f606, 0xaaa0c59dbccd60c3, 0x3bb17e18e2867806, 0x1b1ab6cc8541b367, 0xc2b6ed0ef2158547, 0x11922a097360edf3] 
+                d: [0xa5a9c0759e23f606, 0xaaa0c59dbccd60c3, 0x3bb17e18e2867806, 0x1b1ab6cc8541b367, 0xc2b6ed0ef2158547, 0x11922a097360edf3]
             }],
         },
         y:  Fp2 {
             d: [Fp {
                 d: [0x6d8bf5079fb65e61, 0xc52f05df531d63a5, 0x7f4a4d344ca692c9, 0xa887959b8577c95f, 0x4347fe40525c8734, 0x197d145bbaff0bb5],
             }, Fp {
-                d: [0x0c3e036d209afa4e, 0x0601d8f4863f9e23, 0xe0832636bacc0a84, 0xeb2def362a476f84, 0x64044f659f0ee1e9, 0x0ed54f48d5a1caa7] 
+                d: [0x0c3e036d209afa4e, 0x0601d8f4863f9e23, 0xe0832636bacc0a84, 0xeb2def362a476f84, 0x64044f659f0ee1e9, 0x0ed54f48d5a1caa7]
             }],
         },
         z: Fp2 {
@@ -79,6 +79,6 @@ impl G2 {
             ],
         },
     };
-    
+
 }
 

--- a/mcl/kzg/src/trait_implementations/fft_settings.rs
+++ b/mcl/kzg/src/trait_implementations/fft_settings.rs
@@ -3,10 +3,6 @@ use crate::fk20_fft::{FFTSettings, SCALE_2_ROOT_OF_UNITY_PR7_STRINGS};
 use kzg::FFTSettings as CommonFFTSettings;
 
 impl CommonFFTSettings<Fr> for FFTSettings {
-    fn default() -> Self {
-        FFTSettings::default()
-    }
-
     fn new(scale: usize) -> Result<FFTSettings, String> {
         //currently alawys use PR 7 for shared tests
         FFTSettings::new_custom_primitive_roots(scale as u8, SCALE_2_ROOT_OF_UNITY_PR7_STRINGS)

--- a/mcl/kzg/src/trait_implementations/fk20.rs
+++ b/mcl/kzg/src/trait_implementations/fk20.rs
@@ -6,10 +6,6 @@ use crate::kzg_settings::KZGSettings;
 use kzg::{FK20MultiSettings, FK20SingleSettings};
 
 impl FK20SingleSettings<Fr, G1, G2, FFTSettings, Polynomial, KZGSettings> for FK20SingleMatrix {
-    fn default() -> Self {
-        FK20SingleMatrix::default()
-    }
-
     fn new(ks: &KZGSettings, n2: usize) -> Result<Self, String> {
         FK20SingleMatrix::new(ks, n2)
     }
@@ -24,10 +20,6 @@ impl FK20SingleSettings<Fr, G1, G2, FFTSettings, Polynomial, KZGSettings> for FK
 }
 
 impl FK20MultiSettings<Fr, G1, G2, FFTSettings, Polynomial, KZGSettings> for FK20Matrix {
-    fn default() -> Self {
-        FK20Matrix::default()
-    }
-
     fn new(ks: &KZGSettings, n2: usize, chunk_len: usize) -> Result<Self, String> {
         FK20Matrix::new(ks, n2, chunk_len)
     }

--- a/mcl/kzg/src/trait_implementations/fr.rs
+++ b/mcl/kzg/src/trait_implementations/fr.rs
@@ -2,10 +2,6 @@ use crate::data_types::fr::Fr;
 use kzg::Fr as CommonFr;
 
 impl CommonFr for Fr {
-    fn default() -> Self {
-        Fr::zero()
-    }
-
     fn null() -> Self {
         Fr::from_u64_arr(&[u64::MAX, u64::MAX, u64::MAX, u64::MAX / 3])
     }
@@ -33,13 +29,13 @@ impl CommonFr for Fr {
 	fn to_u64_arr(&self) -> [u64; 4] {
         Fr::to_u64_arr(self)
 	}
-	
+
 	fn div(&self, b: &Self) -> Result<Self, String>{
         let mut res = Fr::zero();
         Fr::div(&mut res, self, b);
         Ok(res)
 	}
-	
+
     fn is_one(&self) -> bool {
         Fr::is_one(self)
     }

--- a/mcl/kzg/src/trait_implementations/kzg_settings.rs
+++ b/mcl/kzg/src/trait_implementations/kzg_settings.rs
@@ -5,10 +5,6 @@ use crate::kzg_settings::KZGSettings;
 use kzg::KZGSettings as CommonKZGSettings;
 
 impl CommonKZGSettings<Fr, G1, G2, FFTSettings, Polynomial> for KZGSettings {
-    fn default() -> Self {
-        KZGSettings::default()
-    }
-
     fn new(secret_g1: &[G1], secret_g2: &[G2], length: usize, fs: &FFTSettings) -> Result<Self, String> {
         KZGSettings::new(secret_g1, secret_g2, length, fs)
     }

--- a/mcl/kzg/src/trait_implementations/poly.rs
+++ b/mcl/kzg/src/trait_implementations/poly.rs
@@ -6,10 +6,6 @@ use kzg::PolyRecover;
 use crate::fk20_fft::FFTSettings;
 
 impl Poly<Fr> for Polynomial {
-    fn default() -> Self {
-        Polynomial { coeffs: vec![] }
-    }
-
     fn new(size: usize) -> Result<Self, String> {
         Ok(Polynomial::new(size))
     }
@@ -46,7 +42,7 @@ impl Poly<Fr> for Polynomial {
         Polynomial::inverse(self, new_len)
     }
 
-    fn div(&mut self, x: &Self) -> Result<Self, String> { 
+    fn div(&mut self, x: &Self) -> Result<Self, String> {
         Polynomial::div(self, &x.coeffs)
     }
 

--- a/zkcrypto/src/curve/scalar.rs
+++ b/zkcrypto/src/curve/scalar.rs
@@ -196,7 +196,7 @@ macro_rules! impl_binops_multiplicative {
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Scalar` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod q, with R = 2^256.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, Eq, Default)]
 pub struct Scalar(pub [u64; 4]);
 
 impl fmt::Debug for Scalar {
@@ -373,13 +373,6 @@ const ROOT_OF_UNITY: Scalar = Scalar([
     0x0af5_3ae3_52a3_1e64,
     0x5bf3_adda_19e9_b27b,
 ]);
-
-impl Default for Scalar {
-    #[inline]
-    fn default() -> Self {
-        Self::zero()
-    }
-}
 
 #[cfg(feature = "zeroize")]
 impl zeroize::DefaultIsZeroes for Scalar {}

--- a/zkcrypto/src/eip_4844.rs
+++ b/zkcrypto/src/eip_4844.rs
@@ -16,7 +16,7 @@ pub fn bytes_from_bls_field(fr: &blsScalar) -> [u8; 32usize] {
 }
 
 pub fn compute_powers(base: &blsScalar, num_powers: usize) -> Vec<blsScalar> {
-    let mut powers: Vec<blsScalar> = vec![<blsScalar as Fr>::default(); num_powers];
+    let mut powers: Vec<blsScalar> = vec![blsScalar::default(); num_powers];
     powers[0] = blsScalar::one();
     for i in 1..num_powers {
         powers[i] = powers[i - 1].mul(base);
@@ -62,7 +62,7 @@ pub fn blob_to_kzg_commitment(blob: &[blsScalar], s: &KZGSettings) -> ZkG1Projec
 }
 
 pub fn fr_batch_inv(out: &mut [blsScalar], a: &[blsScalar], len: usize) {
-    let prod: &mut Vec<blsScalar> = &mut vec![<blsScalar as Fr>::default(); len];
+    let prod: &mut Vec<blsScalar> = &mut vec![blsScalar::default(); len];
     let mut i: usize = 1;
 
     prod[0] = a[0];
@@ -86,8 +86,8 @@ pub fn fr_batch_inv(out: &mut [blsScalar], a: &[blsScalar], len: usize) {
 pub fn evaluate_polynomial_in_evaluation_form(p: &KzgPoly, x: &blsScalar, s: &KZGSettings) -> blsScalar {
     let mut tmp: blsScalar;
 
-    let mut inverses_in: Vec<blsScalar> = vec![<blsScalar as Fr>::default(); p.len()];
-    let mut inverses: Vec<blsScalar> = vec![<blsScalar as Fr>::default(); p.len()];
+    let mut inverses_in: Vec<blsScalar> = vec![blsScalar::default(); p.len()];
+    let mut inverses: Vec<blsScalar> = vec![blsScalar::default(); p.len()];
     let mut i: usize = 0;
     let mut roots_of_unity: Vec<blsScalar> = s.fs.expanded_roots_of_unity.clone();
 

--- a/zkcrypto/src/fft_fr.rs
+++ b/zkcrypto/src/fft_fr.rs
@@ -33,7 +33,7 @@ pub fn fft_fr(
     }
 
     let stride = fft_settings.max_width / data.len();
-    let mut ret = vec![<blsScalar as Fr>::default(); data.len()];
+    let mut ret = vec![blsScalar::default(); data.len()];
 
     let roots = if inverse {
         &fft_settings.reverse_roots_of_unity

--- a/zkcrypto/src/fftsettings.rs
+++ b/zkcrypto/src/fftsettings.rs
@@ -11,7 +11,7 @@ use std::cmp::Ordering;
 // use blst::blst_fr_from_uint64;
 use kzg::{FFTFr, FFTSettings, FFTSettingsPoly, Fr};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ZkFFTSettings {
     pub max_width: usize,
     pub root_of_unity: blsScalar,
@@ -132,7 +132,7 @@ impl FFTFr<blsScalar> for ZkFFTSettings {
 
         // In case more roots are provided with fft_settings, use a larger stride
         let stride = self.max_width / data.len();
-        let mut ret = vec![<blsScalar as Fr>::default(); data.len()];
+        let mut ret = vec![blsScalar::default(); data.len()];
 
         // Inverse is same as regular, but all constants are reversed and results are divided by n
         // This is a property of the DFT matrix
@@ -159,7 +159,7 @@ impl FFTFr<blsScalar> for ZkFFTSettings {
 }
 
 impl ZkFFTSettings {
-    pub fn from_scale(max_scale: usize) -> Result<ZkFFTSettings, String> {
+    pub fn from_scale(max_scale: usize) -> Result<Self, String> {
         if max_scale >= SCALE2_ROOT_OF_UNITY.len() {
             return Err(String::from(
                 "Scale is expected to be within root of unity matrix row size",
@@ -167,24 +167,26 @@ impl ZkFFTSettings {
         }
         let max_width: usize = 1 << max_scale;
 
-        Ok(ZkFFTSettings {
+        Ok(Self {
             max_width,
-            ..FFTSettings::default()
+            ..Self::default()
         })
     }
 }
 
-impl FFTSettings<blsScalar> for ZkFFTSettings {
-    fn default() -> ZkFFTSettings {
-        ZkFFTSettings {
+impl Default for ZkFFTSettings {
+    fn default() -> Self {
+        Self {
             max_width: 0,
             root_of_unity: blsScalar::zero(),
             expanded_roots_of_unity: Vec::new(),
             reverse_roots_of_unity: Vec::new(),
         }
     }
+}
 
-    fn new(scale: usize) -> Result<ZkFFTSettings, String> {
+impl FFTSettings<blsScalar> for ZkFFTSettings {
+    fn new(scale: usize) -> Result<Self, String> {
         if scale >= SCALE2_ROOT_OF_UNITY.len() {
             return Err(String::from(
                 "Scale is expected to be within root of unity matrix row size",
@@ -202,7 +204,7 @@ impl FFTSettings<blsScalar> for ZkFFTSettings {
         let mut reverse_roots_of_unity = expanded_roots_of_unity.clone();
         reverse_roots_of_unity.reverse();
 
-        Ok(ZkFFTSettings {
+        Ok(Self {
             max_width,
             root_of_unity,
             expanded_roots_of_unity,

--- a/zkcrypto/src/fk20.rs
+++ b/zkcrypto/src/fk20.rs
@@ -9,31 +9,16 @@ use kzg::{FFTFr, FK20MultiSettings, FK20SingleSettings, Poly, FFTG1, G1};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+#[derive(Debug, Clone, Default)]
 pub struct ZkFK20SingleSettings {
     pub kzg_settings: KZGSettings,
     pub x_ext_fft: Vec<ZkG1Projective>,
-}
-
-impl Clone for ZkFK20SingleSettings {
-    fn clone(&self) -> Self {
-        Self {
-            kzg_settings: self.kzg_settings.clone(),
-            x_ext_fft: self.x_ext_fft.clone(),
-        }
-    }
 }
 
 impl
     FK20SingleSettings<blsScalar, ZkG1Projective, ZkG2Projective, ZkFFTSettings, ZPoly, KZGSettings>
     for ZkFK20SingleSettings
 {
-    fn default() -> Self {
-        Self {
-            kzg_settings: KZGSettings::default(),
-            x_ext_fft: vec![],
-        }
-    }
-
     fn new(kzg_settings: &KZGSettings, n: usize) -> Result<Self, String> {
         let n2 = n / 2;
 
@@ -103,25 +88,14 @@ impl
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct ZkFK20MultiSettings {
     pub kzg_settings: KZGSettings,
     pub chunk_len: usize,
     pub x_ext_fft_files: Vec<Vec<ZkG1Projective>>,
 }
 
-impl Clone for ZkFK20MultiSettings {
-    fn clone(&self) -> Self {
-        Self {
-            kzg_settings: self.kzg_settings.clone(),
-            chunk_len: self.chunk_len,
-            x_ext_fft_files: self.x_ext_fft_files.clone(),
-        }
-    }
-}
-
-impl FK20MultiSettings<blsScalar, ZkG1Projective, ZkG2Projective, ZkFFTSettings, ZPoly, KZGSettings>
-    for ZkFK20MultiSettings
-{
+impl Default for ZkFK20MultiSettings {
     fn default() -> Self {
         Self {
             kzg_settings: KZGSettings::default(),
@@ -129,7 +103,11 @@ impl FK20MultiSettings<blsScalar, ZkG1Projective, ZkG2Projective, ZkFFTSettings,
             x_ext_fft_files: vec![],
         }
     }
+}
 
+impl FK20MultiSettings<blsScalar, ZkG1Projective, ZkG2Projective, ZkFFTSettings, ZPoly, KZGSettings>
+    for ZkFK20MultiSettings
+{
     #[allow(clippy::many_single_char_names)]
     fn new(ks: &KZGSettings, n: usize, chunk_len: usize) -> Result<Self, String> {
         if n > ks.fs.max_width {

--- a/zkcrypto/src/kzg_proofs.rs
+++ b/zkcrypto/src/kzg_proofs.rs
@@ -8,35 +8,16 @@ use crate::kzg_types::{
     pairings_verify, ZkG1Projective as G1, ZkG2Projective as G2, G1_GENERATOR, G2_GENERATOR,
 };
 
-use kzg::{FFTFr, FFTSettings, Fr, Poly as OtherPoly, G1 as _G1, G2 as _G2};
+use kzg::{FFTFr, Fr, Poly as OtherPoly, G1 as _G1, G2 as _G2};
 
 use crate::curve::multiscalar_mul::msm_variable_base;
 
+#[derive(Debug, Clone, Default)]
 pub struct KZGSettings {
     pub fs: ZkFFTSettings,
     pub secret_g1: Vec<G1>,
     pub secret_g2: Vec<G2>,
     pub length: u64,
-}
-
-impl Default for KZGSettings {
-    fn default() -> KZGSettings {
-        KZGSettings {
-            fs: ZkFFTSettings::default(),
-            secret_g1: Vec::new(),
-            secret_g2: Vec::new(),
-            length: 0,
-        }
-    }
-}
-
-pub fn default_kzg() -> KZGSettings {
-    KZGSettings {
-        fs: ZkFFTSettings::default(),
-        secret_g1: Vec::new(),
-        secret_g2: Vec::new(),
-        length: 0,
-    }
 }
 
 pub(crate) fn new_kzg_settings(

--- a/zkcrypto/src/kzg_types.rs
+++ b/zkcrypto/src/kzg_types.rs
@@ -39,7 +39,7 @@ use kzg::FFTSettings;
 use crate::kzg_proofs::{
     check_proof_multi as check_multi, check_proof_single as check_single,
     commit_to_poly as poly_commit, compute_proof_multi as open_multi,
-    compute_proof_single as open_single, default_kzg, new_kzg_settings,
+    compute_proof_single as open_single, new_kzg_settings,
     KZGSettings as LKZGSettings,
 };
 
@@ -342,10 +342,6 @@ pub fn pairings_verify(
 }
 
 impl KZGSettings<blsScalar, ZkG1Projective, ZkG2Projective, ZkFFTSettings, ZPoly> for LKZGSettings {
-    fn default() -> Self {
-        default_kzg()
-    }
-
     fn new(
         secret_g1: &[ZkG1Projective],
         secret_g2: &[ZkG2Projective],
@@ -400,17 +396,5 @@ impl KZGSettings<blsScalar, ZkG1Projective, ZkG2Projective, ZkFFTSettings, ZPoly
 
     fn get_expanded_roots_of_unity_at(&self, i: usize) -> blsScalar {
         self.fs.get_expanded_roots_of_unity_at(i)
-    }
-}
-
-impl Clone for LKZGSettings {
-    fn clone(&self) -> Self {
-        LKZGSettings::new(
-            &self.secret_g1.clone(),
-            &self.secret_g2.clone(),
-            self.length as usize,
-            &self.fs.clone(),
-        )
-        .unwrap()
     }
 }

--- a/zkcrypto/src/poly.rs
+++ b/zkcrypto/src/poly.rs
@@ -10,14 +10,14 @@ use crate::utils::*;
 // use std::convert::TryInto;
 
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct KzgPoly {
     pub coeffs: Vec<blsScalar>,
 }
 
 impl ZPoly {
     // fn new_poly (size: usize) -> Self {
-    // Self {coeffs: vec![<blsScalar as Fr>::default(); size]}
+    // Self {coeffs: vec![blsScalar::default(); size]}
     // }
 
     /// Checks if the given polynomial is zero.
@@ -93,17 +93,10 @@ impl ZPoly {
 }
 
 impl Poly<blsScalar> for ZPoly {
-    fn default() -> Self {
-        // Self {
-        // coeffs: vec![<blsScalar as Fr>::default(); 4] // blsScalar::default()
-
-        // }
-        Self::new(0).unwrap()
-    }
     fn new(size: usize) -> Result<Self, String> {
         Ok(Self {
-            coeffs: vec![<blsScalar as Fr>::default(); size],
-        }) // blsScalar::default()
+            coeffs: vec![blsScalar::default(); size],
+        })
     }
 
     fn get_coeff_at(&self, i: usize) -> blsScalar {
@@ -182,7 +175,7 @@ impl Poly<blsScalar> for ZPoly {
         }
 
         let mut ret = ZPoly {
-            coeffs: vec![<blsScalar as Fr>::default(); new_len],
+            coeffs: vec![blsScalar::default(); new_len],
         };
 
         if self.coeffs.len() == 1 {

--- a/zkcrypto/src/zkfr.rs
+++ b/zkcrypto/src/zkfr.rs
@@ -13,10 +13,6 @@ use std::convert::TryInto;
 pub use crate::curve::scalar::Scalar as blsScalar;
 
 impl Fr for blsScalar {
-    fn default() -> Self {
-        <blsScalar as Default>::default()
-    }
-
     fn zero() -> Self {
         blsScalar::zero()
     }
@@ -37,7 +33,7 @@ impl Fr for blsScalar {
         let val: [u64; 4] = rand::random();
         blsScalar::from_raw(val)
 
-        // let ret = blsScalar::random(<blsScalar as Fr>::default());
+        // let ret = blsScalar::random(blsScalar::default());
         // ret
 
         // let mut ret = Self::default();
@@ -91,16 +87,16 @@ impl Fr for blsScalar {
     }
 
     fn mul(&self, b: &Self) -> Self {
-        // let mut ret = <blsScalar as Fr>::default(); // Self::default() is this needed?
+        // let mut ret = blsScalar::default(); // Self::default() is this needed?
         blsScalar::mul(self, b) // &b.0 or &ret.0?
     }
 
     fn add(&self, b: &Self) -> Self {
-        // let mut ret = <blsScalar as Fr>::default(); // Self::default() is this needed?
+        // let mut ret = blsScalar::default(); // Self::default() is this needed?
         blsScalar::add(self, b)
     }
     fn sub(&self, b: &Self) -> Self {
-        // let mut ret = <blsScalar as Fr>::default(); // Self::default() is this needed?
+        // let mut ret = blsScalar::default(); // Self::default() is this needed?
         blsScalar::sub(self, b) // for this
     }
 
@@ -140,7 +136,7 @@ impl Fr for blsScalar {
     }
 
     fn inverse(&self) -> Self {
-        //let mut ret = <blsScalar as Fr>::default(); // Self::default()
+        //let mut ret = blsScalar::default(); // Self::default()
         // Self::invert(&self).unwrap()
 
         // let ret = self.invert().unwrap();


### PR DESCRIPTION
Benchmarking CI is still running in my fork, but the other one finished successfully.

This PR tries to make code more idiomatic in Rust in a few ways:
* `fn default()` in some trait replaced with dependency on standard `Default` trait with corresponding re-duplication
* Many data structures got derives (sometimes instead of manual implementation) for traits Debug, Clone, Copy, Eq
* As the result of those changes clippy was able to find numerous places to complain about, those were changed accordingly

The only non-equivalent change is that this was effectively replaced with `Self::new(0)`:
```rust
impl Poly<FsFr> for LPoly {
    fn default() -> Self {
        Self::new(1).unwrap()
    }
```

There was already `Default` was already derived for `LPoly` automatically (with empty coefficients, naturally). In this self-conflicting situation I decided to prefer derived implementation since that is how other implementations are done too.

The rest of changes are mechanical even though API has changed slightly.

There are absolutely still things to improve, but I think this is a decent progress deserving its own PR.