### PR TITLE
Wasm support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy, rustfmt
-
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
@@ -91,6 +85,22 @@ jobs:
           args: --manifest-path zkcrypto/Cargo.toml -- --check
 
       # 3rd team #########################################################
+
+      - name: "[blst-from-scratch][wasm32] Clippy"
+        # Apple's Clang doesn't support WASM, and we are lazy to install it
+        if: runner.os != 'macOS'
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path blst-from-scratch/Cargo.toml --target wasm32-unknown-unknown --no-default-features
+
+      - name: "[blst-from-scratch][wasm32] Build"
+        # Apple's Clang doesn't support WASM, and we are lazy to install it
+        if: runner.os != 'macOS'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path blst-from-scratch/Cargo.toml --target wasm32-unknown-unknown --no-default-features
 
       - name: "[blst-from-scratch] Tests"
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +475,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -856,6 +871,10 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+dependencies = [
+ "atomic-polyfill",
+ "critical-section",
+]
 
 [[package]]
 name = "oorandom"

--- a/blst-from-scratch/Cargo.toml
+++ b/blst-from-scratch/Cargo.toml
@@ -4,20 +4,36 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# TODO: Use `std` feature once https://github.com/supranational/blst/pull/150 or similar upstreamed
 blst = { 'git' = 'https://github.com/supranational/blst.git' }
-rand = "0.8.4"
-kzg = { path = "../kzg" }
-kzg-bench = { path = "../kzg-bench" }
+kzg = { path = "../kzg", default-features = false }
+libc = { version = "0.2.137", optional = true }
+once_cell = { version = "1.4.0", features = ["critical-section"], default-features = false }
+rand = { version = "0.8.4", optional = true }
 rayon = { version = "1.5.1", optional = true }
-once_cell = "1.4.0"
-sha2 = "0.10.6"
-libc = "0.2.137"
+sha2 = { version = "0.10.6", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4.0"
+kzg-bench = { path = "../kzg-bench" }
+rand = "0.8.4"
 
 [features]
-parallel = [ "rayon" ]
+default = [
+    "std",
+    "eip-4844",
+    "rand",
+]
+std = [
+    "once_cell/std",
+    "sha2/std",
+]
+eip-4844 = ["dep:libc"]
+rand = [
+    "dep:rand",
+    "kzg/rand",
+]
+parallel = ["dep:rayon"]
 
 
 [[bench]]

--- a/blst-from-scratch/Cargo.toml
+++ b/blst-from-scratch/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # TODO: Use `std` feature once https://github.com/supranational/blst/pull/150 or similar upstreamed
 blst = { 'git' = 'https://github.com/supranational/blst.git' }
 kzg = { path = "../kzg", default-features = false }
-libc = { version = "0.2.137", optional = true }
+libc = { version = "0.2.137", default-features = false }
 once_cell = { version = "1.4.0", features = ["critical-section"], default-features = false }
 rand = { version = "0.8.4", optional = true }
 rayon = { version = "1.5.1", optional = true }
@@ -21,14 +21,13 @@ rand = "0.8.4"
 [features]
 default = [
     "std",
-    "eip-4844",
     "rand",
 ]
 std = [
+    "libc/std",
     "once_cell/std",
     "sha2/std",
 ]
-eip-4844 = ["dep:libc"]
 rand = [
     "dep:rand",
     "kzg/rand",

--- a/blst-from-scratch/src/data_availability_sampling.rs
+++ b/blst-from-scratch/src/data_availability_sampling.rs
@@ -8,7 +8,6 @@ use kzg::{Fr, DAS};
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
-use crate::utils::is_power_of_two;
 
 // TODO: explain algo
 impl FsFFTSettings {
@@ -79,7 +78,7 @@ impl DAS<FsFr> for FsFFTSettings {
     fn das_fft_extension(&self, evens: &[FsFr]) -> Result<Vec<FsFr>, String> {
         if evens.is_empty() {
             return Err(String::from("A non-zero list ab expected"));
-        } else if !is_power_of_two(evens.len()) {
+        } else if !evens.len().is_power_of_two() {
             return Err(String::from("A list with power-of-two length expected"));
         } else if evens.len() * 2 > self.max_width {
             return Err(String::from(

--- a/blst-from-scratch/src/data_availability_sampling.rs
+++ b/blst-from-scratch/src/data_availability_sampling.rs
@@ -1,5 +1,10 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
 use kzg::{Fr, DAS};
-use std::cmp::Ordering;
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;

--- a/blst-from-scratch/src/eip_4844.rs
+++ b/blst-from-scratch/src/eip_4844.rs
@@ -1,9 +1,21 @@
 #![allow(non_camel_case_types)]
-use std::convert::TryInto;
-use std::ffi::c_char;
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ffi::c_uint;
+#[cfg(feature = "std")]
+use core::ffi::{c_char, c_ulong};
+#[cfg(feature = "std")]
+use core::ptr::null_mut;
+#[cfg(feature = "std")]
 use std::fs::File;
+#[cfg(feature = "std")]
 use std::io::Read;
-use std::ptr::null_mut;
 
 use blst::{
     blst_fr, blst_fr_from_scalar, blst_p1, blst_p1_affine, blst_p1_compress, blst_p1_from_affine,
@@ -12,7 +24,8 @@ use blst::{
 };
 use kzg::{FFTSettings, Fr, KZGSettings, Poly, FFTG1, G1};
 
-use libc::{c_ulong, fgetc, fgets, strtoul, EOF, FILE};
+#[cfg(feature = "std")]
+use libc::{fgetc, fgets, strtoul, EOF, FILE};
 #[cfg(feature = "parallel")]
 use rayon::iter::IntoParallelIterator;
 #[cfg(feature = "parallel")]
@@ -102,6 +115,7 @@ pub fn load_trusted_setup_rust(
     }
 }
 
+#[cfg(feature = "std")]
 pub fn load_trusted_setup_file_rust(file: &mut File) -> FsKZGSettings {
     let mut contents = String::new();
     file.read_to_string(&mut contents)
@@ -137,6 +151,7 @@ pub fn load_trusted_setup_file_rust(file: &mut File) -> FsKZGSettings {
     load_trusted_setup_rust(&g1_projectives, length, &g2_values, n2)
 }
 
+#[cfg(feature = "std")]
 pub fn load_trusted_setup_filename_rust(filename: &str) -> FsKZGSettings {
     let mut file = File::open(filename).expect("Unable to open file");
     load_trusted_setup_file_rust(&mut file)
@@ -505,7 +520,7 @@ pub const C_KZG_RET_C_KZG_OK: C_KZG_RET = 0;
 pub const C_KZG_RET_C_KZG_BADARGS: C_KZG_RET = 1;
 pub const C_KZG_RET_C_KZG_ERROR: C_KZG_RET = 2;
 pub const C_KZG_RET_C_KZG_MALLOC: C_KZG_RET = 3;
-pub type C_KZG_RET = std::os::raw::c_uint;
+pub type C_KZG_RET = c_uint;
 
 const BYTES_PER_BLOB: usize = 32 * FIELD_ELEMENTS_PER_BLOB;
 
@@ -564,7 +579,7 @@ fn fft_settings_to_rust(c_settings: *const CFsFFTSettings) -> FsFFTSettings {
         max_width: settings.max_width as usize,
         root_of_unity: first_root,
         expanded_roots_of_unity: unsafe {
-            std::slice::from_raw_parts(
+            core::slice::from_raw_parts(
                 settings.expanded_roots_of_unity,
                 (settings.max_width + 1) as usize,
             )
@@ -573,7 +588,7 @@ fn fft_settings_to_rust(c_settings: *const CFsFFTSettings) -> FsFFTSettings {
             .collect::<Vec<FsFr>>()
         },
         reverse_roots_of_unity: unsafe {
-            std::slice::from_raw_parts(
+            core::slice::from_raw_parts(
                 settings.reverse_roots_of_unity,
                 (settings.max_width + 1) as usize,
             )
@@ -617,7 +632,7 @@ fn fft_settings_to_c(rust_settings: &FsFFTSettings) -> *const CFsFFTSettings {
 fn kzg_settings_to_rust(c_settings: &CFsKzgSettings) -> FsKZGSettings {
     let length = unsafe { (*c_settings.fs).max_width as usize };
     let secret_g1 = unsafe {
-        std::slice::from_raw_parts(c_settings.g1_values, length)
+        core::slice::from_raw_parts(c_settings.g1_values, length)
             .iter()
             .map(|r| FsG1(*r))
             .collect::<Vec<FsG1>>()
@@ -626,7 +641,7 @@ fn kzg_settings_to_rust(c_settings: &CFsKzgSettings) -> FsKZGSettings {
         fs: fft_settings_to_rust(c_settings.fs),
         secret_g1,
         secret_g2: unsafe {
-            std::slice::from_raw_parts(c_settings.g2_values, 65)
+            core::slice::from_raw_parts(c_settings.g2_values, 65)
                 .iter()
                 .map(|r| FsG2(*r))
                 .collect::<Vec<FsG2>>()
@@ -712,8 +727,8 @@ pub unsafe extern "C" fn load_trusted_setup(
     g2_bytes: *const u8,
     n2: usize,
 ) -> C_KZG_RET {
-    let g1_bytes = std::slice::from_raw_parts(g1_bytes, n1 * 48);
-    let g2_bytes = std::slice::from_raw_parts(g2_bytes, n2 * 96);
+    let g1_bytes = core::slice::from_raw_parts(g1_bytes, n1 * 48);
+    let g2_bytes = core::slice::from_raw_parts(g2_bytes, n2 * 96);
     let settings = load_trusted_setup_rust(g1_bytes, n1, g2_bytes, n2);
     *out = kzg_settings_to_c(&settings);
     C_KZG_RET_C_KZG_OK
@@ -724,6 +739,7 @@ pub unsafe extern "C" fn load_trusted_setup(
 /// # Safety
 ///
 /// This function should not be called before the horsemen are ready.
+#[cfg(feature = "std")]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup_file(
     out: *mut CFsKzgSettings,
@@ -789,7 +805,7 @@ pub unsafe extern "C" fn compute_aggregate_kzg_proof(
     n: usize,
     s: &CFsKzgSettings,
 ) -> C_KZG_RET {
-    let raw_blob_arr = std::slice::from_raw_parts(blobs, n);
+    let raw_blob_arr = core::slice::from_raw_parts(blobs, n);
     let mut blob_arr: Vec<Vec<FsFr>> = Vec::<Vec<FsFr>>::default();
     for i in 0..n {
         blob_arr.push(Vec::<FsFr>::default());
@@ -815,24 +831,24 @@ pub unsafe extern "C" fn compute_aggregate_kzg_proof(
 /// This function should not be called before the horsemen are ready
 pub unsafe extern "C" fn free_trusted_setup(s: *mut CFsKzgSettings) {
     let max_width = (*(*s).fs).max_width as usize;
-    let rev = Box::from_raw(std::slice::from_raw_parts_mut(
+    let rev = Box::from_raw(core::slice::from_raw_parts_mut(
         (*(*s).fs).reverse_roots_of_unity,
         max_width,
     ));
     drop(rev);
-    let exp = Box::from_raw(std::slice::from_raw_parts_mut(
+    let exp = Box::from_raw(core::slice::from_raw_parts_mut(
         (*(*s).fs).expanded_roots_of_unity,
         max_width,
     ));
     drop(exp);
-    let roots = Box::from_raw(std::slice::from_raw_parts_mut(
+    let roots = Box::from_raw(core::slice::from_raw_parts_mut(
         (*(*s).fs).roots_of_unity,
         max_width,
     ));
     drop(roots);
-    let g1 = Box::from_raw(std::slice::from_raw_parts_mut((*s).g1_values, max_width));
+    let g1 = Box::from_raw(core::slice::from_raw_parts_mut((*s).g1_values, max_width));
     drop(g1);
-    let g2 = Box::from_raw(std::slice::from_raw_parts_mut((*s).g2_values, 65));
+    let g2 = Box::from_raw(core::slice::from_raw_parts_mut((*s).g2_values, 65));
     drop(g2);
 }
 
@@ -874,7 +890,7 @@ pub unsafe extern "C" fn verify_aggregate_kzg_proof(
     aggregated_proof_bytes: *const Bytes48,
     s: &CFsKzgSettings,
 ) -> C_KZG_RET {
-    let raw_blob_arr = std::slice::from_raw_parts(blobs, n);
+    let raw_blob_arr = core::slice::from_raw_parts(blobs, n);
     let mut blob_arr: Vec<Vec<FsFr>> = Vec::<Vec<FsFr>>::default();
     for i in 0..n {
         blob_arr.push(Vec::<FsFr>::default());
@@ -890,7 +906,7 @@ pub unsafe extern "C" fn verify_aggregate_kzg_proof(
         }
     }
     let mut expected_kzg_commitments_arr = Vec::new();
-    let expected_kzg_commitments_raw = std::slice::from_raw_parts(commitments_bytes, n);
+    let expected_kzg_commitments_raw = core::slice::from_raw_parts(commitments_bytes, n);
     for x in expected_kzg_commitments_raw.iter() {
         let tmp = bytes_to_g1_rust(&x.bytes);
         if tmp.is_err() {

--- a/blst-from-scratch/src/eip_4844.rs
+++ b/blst-from-scratch/src/eip_4844.rs
@@ -505,7 +505,7 @@ pub const C_KZG_RET_C_KZG_OK: C_KZG_RET = 0;
 pub const C_KZG_RET_C_KZG_BADARGS: C_KZG_RET = 1;
 pub const C_KZG_RET_C_KZG_ERROR: C_KZG_RET = 2;
 pub const C_KZG_RET_C_KZG_MALLOC: C_KZG_RET = 3;
-pub type C_KZG_RET = ::std::os::raw::c_uint;
+pub type C_KZG_RET = std::os::raw::c_uint;
 
 const BYTES_PER_BLOB: usize = 32 * FIELD_ELEMENTS_PER_BLOB;
 

--- a/blst-from-scratch/src/fft_fr.rs
+++ b/blst-from-scratch/src/fft_fr.rs
@@ -8,7 +8,6 @@ use kzg::{FFTFr, Fr};
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
-use crate::utils::is_power_of_two;
 
 /// Fast Fourier Transform for finite field elements. Polynomial ret is operated on in reverse order: ret_i * x ^ (len - i - 1)
 pub fn fft_fr_fast(
@@ -73,7 +72,7 @@ impl FFTFr<FsFr> for FsFFTSettings {
             return Err(String::from(
                 "Supplied list is longer than the available max width",
             ));
-        } else if !is_power_of_two(data.len()) {
+        } else if !data.len().is_power_of_two() {
             return Err(String::from("A list with power-of-two length expected"));
         }
 

--- a/blst-from-scratch/src/fft_fr.rs
+++ b/blst-from-scratch/src/fft_fr.rs
@@ -1,3 +1,9 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{FFTFr, Fr};
 
 use crate::types::fft_settings::FsFFTSettings;

--- a/blst-from-scratch/src/fft_g1.rs
+++ b/blst-from-scratch/src/fft_g1.rs
@@ -1,3 +1,9 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{Fr, G1Mul, FFTG1, G1};
 
 use crate::types::fft_settings::FsFFTSettings;

--- a/blst-from-scratch/src/fft_g1.rs
+++ b/blst-from-scratch/src/fft_g1.rs
@@ -9,7 +9,6 @@ use kzg::{Fr, G1Mul, FFTG1, G1};
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
 use crate::types::g1::FsG1;
-use crate::utils::is_power_of_two;
 
 pub fn fft_g1_fast(
     ret: &mut [FsG1],
@@ -57,7 +56,7 @@ impl FFTG1<FsG1> for FsFFTSettings {
             return Err(String::from(
                 "Supplied list is longer than the available max width",
             ));
-        } else if !is_power_of_two(data.len()) {
+        } else if !data.len().is_power_of_two() {
             return Err(String::from("A list with power-of-two length expected"));
         }
 

--- a/blst-from-scratch/src/fk20_proofs.rs
+++ b/blst-from-scratch/src/fk20_proofs.rs
@@ -1,3 +1,8 @@
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{FFTFr, Fr, G1Mul, Poly, FFTG1, G1};
 
 use crate::types::fft_settings::FsFFTSettings;

--- a/blst-from-scratch/src/kzg_proofs.rs
+++ b/blst-from-scratch/src/kzg_proofs.rs
@@ -1,4 +1,8 @@
-use std::ptr;
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ptr;
 
 use blst::{
     blst_final_exp, blst_fp12, blst_fp12_is_one, blst_fp12_mul, blst_miller_loop, blst_p1,

--- a/blst-from-scratch/src/lib.rs
+++ b/blst-from-scratch/src/lib.rs
@@ -1,5 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod consts;
 pub mod data_availability_sampling;
+#[cfg(feature = "eip-4844")]
 pub mod eip_4844;
 pub mod fft_fr;
 pub mod fft_g1;

--- a/blst-from-scratch/src/lib.rs
+++ b/blst-from-scratch/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub mod consts;
 pub mod data_availability_sampling;
-#[cfg(feature = "eip-4844")]
 pub mod eip_4844;
 pub mod fft_fr;
 pub mod fft_g1;

--- a/blst-from-scratch/src/recovery.rs
+++ b/blst-from-scratch/src/recovery.rs
@@ -9,7 +9,6 @@ use kzg::{FFTFr, Fr, ZeroPoly};
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
 use crate::types::poly::FsPoly;
-use crate::utils::{is_power_of_two, next_power_of_two};
 use once_cell::sync::OnceCell;
 
 const SCALE_FACTOR: u64 = 5;
@@ -52,7 +51,7 @@ pub fn recover_poly_from_samples(
     len_samples: usize,
     fs: &FsFFTSettings,
 ) -> Result<Vec<FsFr>, String> {
-    if !is_power_of_two(len_samples) {
+    if !len_samples.is_power_of_two() {
         return Err(String::from("len_samples must be a power of two"));
     }
 
@@ -96,7 +95,7 @@ pub fn recover_poly_from_samples(
     // x -> k * x
     let len_zero_poly = zero_poly.coeffs.len();
 
-    let _zero_poly_scale = next_power_of_two(len_zero_poly - 1);
+    let _zero_poly_scale = (len_zero_poly - 1).next_power_of_two();
     #[cfg(feature = "parallel")]
     {
         if _zero_poly_scale > 1024 {

--- a/blst-from-scratch/src/recovery.rs
+++ b/blst-from-scratch/src/recovery.rs
@@ -1,3 +1,9 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{FFTFr, Fr, ZeroPoly};
 
 use crate::types::fft_settings::FsFFTSettings;
@@ -10,7 +16,6 @@ const SCALE_FACTOR: u64 = 5;
 static INVERSE_FACTORS: OnceCell<Vec<FsFr>> = OnceCell::new();
 static UNSCALE_FACTOR_POWERS: OnceCell<Vec<FsFr>> = OnceCell::new();
 
-#[allow(clippy::needless_range_loop)]
 pub fn scale_poly(p: &mut [FsFr], len_p: usize) {
     let factors = INVERSE_FACTORS.get_or_init(|| {
         let scale_factor = FsFr::from_u64(SCALE_FACTOR);
@@ -27,7 +32,6 @@ pub fn scale_poly(p: &mut [FsFr], len_p: usize) {
     }
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn unscale_poly(p: &mut [FsFr], len_p: usize) {
     let factors = UNSCALE_FACTOR_POWERS.get_or_init(|| {
         let scale_factor = FsFr::from_u64(SCALE_FACTOR);

--- a/blst-from-scratch/src/types/fft_settings.rs
+++ b/blst-from-scratch/src/types/fft_settings.rs
@@ -1,3 +1,9 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{FFTSettings, Fr};
 
 use crate::consts::SCALE2_ROOT_OF_UNITY;

--- a/blst-from-scratch/src/types/fk20_multi_settings.rs
+++ b/blst-from-scratch/src/types/fk20_multi_settings.rs
@@ -12,7 +12,7 @@ use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 use crate::types::kzg_settings::FsKZGSettings;
 use crate::types::poly::FsPoly;
-use crate::utils::{is_power_of_two, reverse_bit_order};
+use crate::utils::reverse_bit_order;
 
 pub struct FsFK20MultiSettings {
     pub kzg_settings: FsKZGSettings,
@@ -49,13 +49,13 @@ impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             return Err(String::from(
                 "n2 must be less than or equal to kzg settings max width",
             ));
-        } else if !is_power_of_two(n2) {
+        } else if !n2.is_power_of_two() {
             return Err(String::from("n2 must be a power of two"));
         } else if n2 < 2 {
             return Err(String::from("n2 must be greater than or equal to 2"));
         } else if chunk_len > n2 / 2 {
             return Err(String::from("chunk_len must be greater or equal to n2 / 2"));
-        } else if !is_power_of_two(chunk_len) {
+        } else if !chunk_len.is_power_of_two() {
             return Err(String::from("chunk_len must be a power of two"));
         }
 
@@ -111,7 +111,7 @@ impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             ));
         }
 
-        if !is_power_of_two(n2) {
+        if !n2.is_power_of_two() {
             return Err(String::from("n2 must be a power of two"));
         }
 
@@ -129,7 +129,7 @@ impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             return Err(String::from(
                 "n2 must be less than or equal to kzg settings max width",
             ));
-        } else if !is_power_of_two(n2) {
+        } else if !n2.is_power_of_two() {
             return Err(String::from("n2 must be a power of two"));
         }
 

--- a/blst-from-scratch/src/types/fk20_multi_settings.rs
+++ b/blst-from-scratch/src/types/fk20_multi_settings.rs
@@ -1,3 +1,9 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{FK20MultiSettings, Poly, FFTG1, G1};
 
 use crate::types::fft_settings::FsFFTSettings;

--- a/blst-from-scratch/src/types/fk20_single_settings.rs
+++ b/blst-from-scratch/src/types/fk20_single_settings.rs
@@ -11,7 +11,7 @@ use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 use crate::types::kzg_settings::FsKZGSettings;
 use crate::types::poly::FsPoly;
-use crate::utils::{is_power_of_two, reverse_bit_order};
+use crate::utils::reverse_bit_order;
 
 #[derive(Debug, Clone, Default)]
 pub struct FsFK20SingleSettings {
@@ -29,7 +29,7 @@ impl FK20SingleSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             return Err(String::from(
                 "n2 must be less than or equal to kzg settings max width",
             ));
-        } else if !is_power_of_two(n2) {
+        } else if !n2.is_power_of_two() {
             return Err(String::from("n2 must be a power of two"));
         } else if n2 < 2 {
             return Err(String::from("n2 must be greater than or equal to 2"));
@@ -60,7 +60,7 @@ impl FK20SingleSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             return Err(String::from(
                 "n2 must be less than or equal to kzg settings max width",
             ));
-        } else if !is_power_of_two(n2) {
+        } else if !n2.is_power_of_two() {
             return Err(String::from("n2 must be a power of two"));
         }
 
@@ -78,7 +78,7 @@ impl FK20SingleSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             return Err(String::from(
                 "n2 must be less than or equal to kzg settings max width",
             ));
-        } else if !is_power_of_two(n2) {
+        } else if !n2.is_power_of_two() {
             return Err(String::from("n2 must be a power of two"));
         }
 

--- a/blst-from-scratch/src/types/fk20_single_settings.rs
+++ b/blst-from-scratch/src/types/fk20_single_settings.rs
@@ -1,3 +1,8 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use kzg::{FK20SingleSettings, Poly, FFTG1, G1};
 
 use crate::types::fft_settings::FsFFTSettings;

--- a/blst-from-scratch/src/types/fr.rs
+++ b/blst-from-scratch/src/types/fr.rs
@@ -1,3 +1,7 @@
+extern crate alloc;
+
+use alloc::string::String;
+
 use blst::{
     blst_fr, blst_fr_add, blst_fr_cneg, blst_fr_eucl_inverse, blst_fr_from_scalar,
     blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_sqr, blst_fr_sub, blst_scalar,
@@ -21,6 +25,7 @@ impl Fr for FsFr {
         Self::from_u64(1)
     }
 
+    #[cfg(feature = "rand")]
     fn rand() -> Self {
         let val: [u64; 4] = [
             rand::random(),

--- a/blst-from-scratch/src/types/g1.rs
+++ b/blst-from-scratch/src/types/g1.rs
@@ -2,7 +2,7 @@ use blst::{
     blst_fp, blst_p1, blst_p1_add_or_double, blst_p1_cneg, blst_p1_double, blst_p1_is_equal,
     blst_p1_is_inf, blst_p1_mult, blst_scalar, blst_scalar_from_fr,
 };
-use kzg::{Fr, G1Mul, G1};
+use kzg::{G1Mul, G1};
 
 use crate::consts::{G1_GENERATOR, G1_IDENTITY, G1_NEGATIVE_GENERATOR};
 use crate::types::fr::FsFr;
@@ -35,9 +35,10 @@ impl G1 for FsG1 {
         G1_NEGATIVE_GENERATOR
     }
 
+    #[cfg(feature = "rand")]
     fn rand() -> Self {
         let result: FsG1 = G1_GENERATOR;
-        result.mul(&FsFr::rand())
+        result.mul(&kzg::Fr::rand())
     }
 
     fn add_or_dbl(&mut self, b: &Self) -> Self {

--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -20,7 +20,7 @@ impl G2Mul<FsFr> for FsG2 {
                 &mut result,
                 &self.0,
                 scalar.b.as_ptr(),
-                8 * std::mem::size_of::<blst_scalar>(),
+                8 * core::mem::size_of::<blst_scalar>(),
             );
         }
         Self(result)

--- a/blst-from-scratch/src/types/kzg_settings.rs
+++ b/blst-from-scratch/src/types/kzg_settings.rs
@@ -1,3 +1,8 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use kzg::{FFTFr, FFTSettings, Fr, G1Mul, G2Mul, KZGSettings, Poly, G1, G2};
 
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};

--- a/blst-from-scratch/src/types/kzg_settings.rs
+++ b/blst-from-scratch/src/types/kzg_settings.rs
@@ -12,7 +12,6 @@ use crate::types::fr::FsFr;
 use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 use crate::types::poly::FsPoly;
-use crate::utils::is_power_of_two;
 
 #[derive(Debug, Clone, Default)]
 pub struct FsKZGSettings {
@@ -90,7 +89,7 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly> for FsKZGSettings {
     }
 
     fn compute_proof_multi(&self, p: &FsPoly, x0: &FsFr, n: usize) -> Result<FsG1, String> {
-        if !is_power_of_two(n) {
+        if !n.is_power_of_two() {
             return Err(String::from("n must be a power of two"));
         }
 
@@ -129,7 +128,7 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly> for FsKZGSettings {
         ys: &[FsFr],
         n: usize,
     ) -> Result<bool, String> {
-        if !is_power_of_two(n) {
+        if !n.is_power_of_two() {
             return Err(String::from("n is not a power of two"));
         }
 

--- a/blst-from-scratch/src/types/poly.rs
+++ b/blst-from-scratch/src/types/poly.rs
@@ -1,3 +1,9 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use kzg::{FFTFr, FFTSettings, FFTSettingsPoly, Fr, Poly, PolyRecover, ZeroPoly};
 
 use crate::consts::SCALE_FACTOR;

--- a/blst-from-scratch/src/utils.rs
+++ b/blst-from-scratch/src/utils.rs
@@ -1,3 +1,7 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 use kzg::{Fr, G1Mul, G2Mul};
 
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};
@@ -5,10 +9,12 @@ use crate::types::fr::FsFr;
 use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 
+// TODO: Should be replaced with `x.is_power_of_two()`
 pub fn is_power_of_two(x: usize) -> bool {
     (x != 0) && ((x & (x - 1)) == 0)
 }
 
+// TODO: Should this function be replaced with `v.next_power_of_two()`?
 pub fn next_power_of_two(v: usize) -> usize {
     let mut v = v;
 
@@ -18,7 +24,10 @@ pub fn next_power_of_two(v: usize) -> usize {
     v |= v >> 4;
     v |= v >> 8;
     v |= v >> 16;
-    v |= v >> 32;
+    #[cfg(target_pointer_width = "64")]
+    {
+        v |= v >> 32;
+    }
     v += 1;
     if v == 0 {
         v += 1

--- a/blst-from-scratch/src/utils.rs
+++ b/blst-from-scratch/src/utils.rs
@@ -9,33 +9,6 @@ use crate::types::fr::FsFr;
 use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 
-// TODO: Should be replaced with `x.is_power_of_two()`
-pub fn is_power_of_two(x: usize) -> bool {
-    (x != 0) && ((x & (x - 1)) == 0)
-}
-
-// TODO: Should this function be replaced with `v.next_power_of_two()`?
-pub fn next_power_of_two(v: usize) -> usize {
-    let mut v = v;
-
-    v -= 1;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    #[cfg(target_pointer_width = "64")]
-    {
-        v |= v >> 32;
-    }
-    v += 1;
-    if v == 0 {
-        v += 1
-    }
-
-    v
-}
-
 pub fn log_2_byte(b: u8) -> usize {
     let mut r = u8::from(b > 0xF) << 2;
     let mut b = b >> r;
@@ -63,22 +36,6 @@ pub fn log2_u64(n: usize) -> usize {
         r += 1;
     }
     r
-}
-
-pub fn min_u64(a: usize, b: usize) -> usize {
-    if a < b {
-        a
-    } else {
-        b
-    }
-}
-
-pub fn max_u64(a: usize, b: usize) -> usize {
-    if a < b {
-        b
-    } else {
-        a
-    }
 }
 
 pub fn generate_trusted_setup(n: usize, secret: [u8; 32usize]) -> (Vec<FsG1>, Vec<FsG2>) {

--- a/blst-from-scratch/src/zero_poly.rs
+++ b/blst-from-scratch/src/zero_poly.rs
@@ -1,4 +1,9 @@
-use std::cmp::{min, Ordering};
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::{min, Ordering};
 
 use kzg::{FFTFr, Fr, ZeroPoly};
 

--- a/blst-from-scratch/src/zero_poly.rs
+++ b/blst-from-scratch/src/zero_poly.rs
@@ -10,7 +10,6 @@ use kzg::{FFTFr, Fr, ZeroPoly};
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
 use crate::types::poly::FsPoly;
-use crate::utils::{is_power_of_two, next_power_of_two};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -82,7 +81,7 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
     /// Reduce partials using a specified domain size.
     /// Calculates the product of all polynomials via FFT and then applies an inverse FFT to produce a new Polynomial.
     fn reduce_partials(&self, domain_size: usize, partials: &[FsPoly]) -> Result<FsPoly, String> {
-        if !is_power_of_two(domain_size) {
+        if !domain_size.is_power_of_two() {
             return Err(String::from("Expected domain size to be a power of 2"));
         }
 
@@ -140,7 +139,7 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
             return Err(String::from(
                 "Domain size greater than fft_settings.max_width",
             ));
-        } else if !is_power_of_two(domain_size) {
+        } else if !domain_size.is_power_of_two() {
             return Err(String::from("Domain size must be a power of 2"));
         }
 
@@ -150,7 +149,7 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
 
         let mut partial_count = 1 + (missing_idxs.len() - 1) / missing_per_partial; // TODO: explain why -1 is used here
 
-        let next_pow: usize = next_power_of_two(partial_count * degree_of_partial);
+        let next_pow: usize = (partial_count * degree_of_partial).next_power_of_two();
         let domain_ceiling = min(next_pow, domain_size);
         // Calculate zero poly
         if missing_idxs.len() <= missing_per_partial {
@@ -167,7 +166,7 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
 
             #[cfg(not(feature = "parallel"))]
             {
-                work = vec![FsFr::zero(); next_power_of_two(partial_count * degree_of_partial)];
+                work = vec![FsFr::zero(); (partial_count * degree_of_partial).next_power_of_two()];
 
                 let mut missing_offset = 0;
                 let mut work_offset = 0;
@@ -253,7 +252,7 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
             let reduction_factor = 4; // Can be tuned & optimized (but must be a power of 2)
             while partial_count > 1 {
                 let reduced_count = 1 + (partial_count - 1) / reduction_factor;
-                let partial_size = next_power_of_two(partial_lens[0]);
+                let partial_size = partial_lens[0].next_power_of_two();
 
                 // Step over polynomial space and produce larger multiplied polynomials
                 for i in 0..reduced_count {

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -2,3 +2,7 @@
 name = "kzg"
 version = "0.1.0"
 edition = "2021"
+
+[features]
+default = ["rand"]
+rand = []

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -7,6 +7,7 @@ pub trait Fr: Default + Clone {
 
     fn one() -> Self;
 
+    #[cfg(feature = "rand")]
     fn rand() -> Self;
 
     fn from_u64_arr(u: &[u64; 4]) -> Self;
@@ -51,6 +52,7 @@ pub trait G1: Clone {
 
     fn negative_generator() -> Self;
 
+    #[cfg(feature = "rand")]
     fn rand() -> Self;
 
     fn add_or_dbl(&mut self, b: &Self) -> Self;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 channel = 'stable-2022-11-03'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Initially my goal was to make it `no_std` compatible and it almost is, but `blst` isn't (see https://github.com/supranational/blst/pull/150), without that it still compiles for `wasm32-unknown-unknown` target, but wouldn't work for target that doesn't have standard library at all.

I'll send a PR with full `no_std` support once https://github.com/supranational/blst/pull/150 or similar is upstreamed.

Wasm is skipped in CI on macOS because it needs proper Clang with wasm support and not the default Apple's contraption. But it didn't seem worthwhile to add LLVM installation on top since if it works on Linux and Windows, it'll work the same exact way on macOS too given compiler support.