### PR TITLE
Make `G1` and `G2` traits depend on `Default` rather than having own `default` method

### DIFF
--- a/Arkworks/src/kzg_types.rs
+++ b/Arkworks/src/kzg_types.rs
@@ -24,8 +24,8 @@ use kzg::{FFTSettings, FFTSettingsPoly, Fr, G1Mul, G2Mul, KZGSettings, Poly, G1,
 use std::ops::MulAssign;
 use std::ops::Neg;
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct ArkG1(pub blst::blst_p1);
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ArkG1(pub blst_p1);
 
 impl Clone for ArkG1 {
     fn clone(&self) -> Self {
@@ -34,10 +34,6 @@ impl Clone for ArkG1 {
 }
 
 impl G1 for ArkG1 {
-    fn default() -> Self {
-        Self(blst_p1::default())
-    }
-
     fn add_or_dbl(&mut self, b: &Self) -> Self {
         let temp = blst_p1_into_pc_g1projective(&self.0).unwrap()
             + blst_p1_into_pc_g1projective(&b.0).unwrap();
@@ -96,7 +92,7 @@ impl G1Mul<FsFr> for ArkG1 {
 
 impl Copy for ArkG1 {}
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ArkG2(pub blst::blst_p2);
 
 impl Clone for ArkG2 {
@@ -106,10 +102,6 @@ impl Clone for ArkG2 {
 }
 
 impl G2 for ArkG2 {
-    fn default() -> Self {
-        todo!()
-    }
-
     fn generator() -> Self {
         G2_GENERATOR
     }

--- a/blst-from-scratch/src/types/g1.rs
+++ b/blst-from-scratch/src/types/g1.rs
@@ -9,7 +9,7 @@ use crate::types::fr::FsFr;
 use crate::utils::log_2_byte;
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct FsG1(pub blst_p1);
 
 impl FsG1 {
@@ -19,10 +19,6 @@ impl FsG1 {
 }
 
 impl G1 for FsG1 {
-    fn default() -> Self {
-        Self(blst_p1::default())
-    }
-
     fn identity() -> Self {
         G1_IDENTITY
     }

--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -7,7 +7,7 @@ use kzg::{G2Mul, G2};
 use crate::consts::{G2_GENERATOR, G2_NEGATIVE_GENERATOR};
 use crate::types::fr::FsFr;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct FsG2(pub blst_p2);
 
 impl G2Mul<FsFr> for FsG2 {
@@ -28,10 +28,6 @@ impl G2Mul<FsFr> for FsG2 {
 }
 
 impl G2 for FsG2 {
-    fn default() -> Self {
-        Self(blst_p2::default())
-    }
-
     fn generator() -> Self {
         G2_GENERATOR
     }

--- a/ckzg/src/fftsettings.rs
+++ b/ckzg/src/fftsettings.rs
@@ -212,7 +212,7 @@ fn _fft_g1(
     n: u64,
     fs: *const KzgFFTSettings,
 ) -> Result<Vec<BlstP1>, KzgRet> {
-    let mut output = vec![G1::default(); n as usize];
+    let mut output = vec![BlstP1::default(); n as usize];
     unsafe {
         match fft_g1(output.as_mut_ptr(), input, inverse, n, fs, RUN_PARALLEL) {
             KzgRet::KzgOk => Ok(output),
@@ -337,7 +337,7 @@ pub fn make_data(n: usize) -> Vec<BlstP1> {
     let mut out_val = vec![G1::generator(); n];
     let out_ptr: *mut BlstP1 = out_val.as_mut_ptr();
     if n == 0 {
-        return vec![G1::default(); 0];
+        return vec![BlstP1::default(); 0];
     }
     for i in 1..n as isize {
         unsafe {

--- a/ckzg/src/finite.rs
+++ b/ckzg/src/finite.rs
@@ -1,5 +1,5 @@
 use crate::consts::{
-    BlstFp, BlstFp2, BlstP1, BlstP1Affine, BlstP2, BlstP2Affine, BLST_ERROR, G1_NEGATIVE_GENERATOR,
+    BlstFp, BlstP1, BlstP1Affine, BlstP2, BlstP2Affine, BLST_ERROR, G1_NEGATIVE_GENERATOR,
     G2_NEGATIVE_GENERATOR,
 };
 
@@ -220,14 +220,6 @@ impl Fr for BlstFr {
 }
 
 impl G1 for BlstP1 {
-    fn default() -> Self {
-        Self {
-            x: BlstFp { l: [0; 6] },
-            y: BlstFp { l: [0; 6] },
-            z: BlstFp { l: [0; 6] },
-        }
-    }
-
     fn identity() -> Self {
         Self {
             x: BlstFp { l: [0; 6] },
@@ -245,7 +237,7 @@ impl G1 for BlstP1 {
     }
 
     fn rand() -> Self {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         let random = Fr::rand();
         unsafe {
             g1_mul(&mut ret, &G1::generator(), &random);
@@ -254,7 +246,7 @@ impl G1 for BlstP1 {
     }
 
     fn add_or_dbl(&mut self, b: &Self) -> Self {
-        let mut out = G1::default();
+        let mut out = BlstP1::default();
         unsafe {
             g1_add_or_dbl(&mut out, b, self);
         }
@@ -266,7 +258,7 @@ impl G1 for BlstP1 {
     }
 
     fn dbl(&self) -> Self {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         unsafe {
             g1_dbl(&mut ret, self);
         }
@@ -274,7 +266,7 @@ impl G1 for BlstP1 {
     }
 
     fn sub(&self, b: &Self) -> Self {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         unsafe {
             g1_sub(&mut ret, self, b);
         }
@@ -288,7 +280,7 @@ impl G1 for BlstP1 {
 
 impl G1Mul<BlstFr> for BlstP1 {
     fn mul(&self, b: &BlstFr) -> Self {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         unsafe {
             g1_mul(&mut ret, self, b);
         }
@@ -297,20 +289,6 @@ impl G1Mul<BlstFr> for BlstP1 {
 }
 
 impl G2 for BlstP2 {
-    fn default() -> Self {
-        Self {
-            x: BlstFp2 {
-                fp: [BlstFp { l: [0; 6] }, BlstFp { l: [0; 6] }],
-            },
-            y: BlstFp2 {
-                fp: [BlstFp { l: [0; 6] }, BlstFp { l: [0; 6] }],
-            },
-            z: BlstFp2 {
-                fp: [BlstFp { l: [0; 6] }, BlstFp { l: [0; 6] }],
-            },
-        }
-    }
-
     fn generator() -> Self {
         unsafe { *blst_p2_generator() }
     }
@@ -320,7 +298,7 @@ impl G2 for BlstP2 {
     }
 
     fn add_or_dbl(&mut self, b: &Self) -> Self {
-        let mut ret = G2::default();
+        let mut ret = BlstP2::default();
         unsafe {
             g2_add_or_dbl(&mut ret, self, b);
         }
@@ -328,7 +306,7 @@ impl G2 for BlstP2 {
     }
 
     fn dbl(&self) -> Self {
-        let mut ret = G2::default();
+        let mut ret = BlstP2::default();
         unsafe {
             g2_dbl(&mut ret, self);
         }
@@ -336,7 +314,7 @@ impl G2 for BlstP2 {
     }
 
     fn sub(&self, b: &Self) -> Self {
-        let mut ret = G2::default();
+        let mut ret = BlstP2::default();
         unsafe {
             g2_sub(&mut ret, self, b);
         }
@@ -350,7 +328,7 @@ impl G2 for BlstP2 {
 
 impl G2Mul<BlstFr> for BlstP2 {
     fn mul(&self, b: &BlstFr) -> Self {
-        let mut ret = G2::default();
+        let mut ret = BlstP2::default();
         unsafe {
             g2_mul(&mut ret, self, b);
         }

--- a/ckzg/src/fk20settings.rs
+++ b/ckzg/src/fk20settings.rs
@@ -1,4 +1,4 @@
-use kzg::{FK20MultiSettings, FK20SingleSettings, Poly, G1};
+use kzg::{FK20MultiSettings, FK20SingleSettings, Poly};
 
 use crate::consts::{BlstP1, BlstP2, KzgRet};
 use crate::fftsettings::KzgFFTSettings;
@@ -70,7 +70,7 @@ impl Default for KzgFK20SingleSettings {
     fn default() -> Self {
         Self {
             ks: &KzgKZGSettings::default(),
-            x_ext_fft: &mut G1::default(),
+            x_ext_fft: &mut BlstP1::default(),
             x_ext_fft_len: 0,
         }
     }
@@ -93,7 +93,7 @@ impl FK20SingleSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGS
     }
 
     fn data_availability(&self, p: &KzgPoly) -> Result<Vec<BlstP1>, String> {
-        let mut ret = vec![G1::default(); 2 * p.len() as usize];
+        let mut ret = vec![BlstP1::default(); 2 * p.len() as usize];
         unsafe {
             match da_using_fk20_single(ret.as_mut_ptr(), p, self, RUN_PARALLEL) {
                 KzgRet::KzgOk => Ok(ret),
@@ -106,7 +106,7 @@ impl FK20SingleSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGS
     }
 
     fn data_availability_optimized(&self, p: &KzgPoly) -> Result<Vec<BlstP1>, String> {
-        let mut ret = vec![G1::default(); 2 * p.len() as usize];
+        let mut ret = vec![BlstP1::default(); 2 * p.len() as usize];
         unsafe {
             match fk20_single_da_opt(ret.as_mut_ptr(), p, self, RUN_PARALLEL) {
                 KzgRet::KzgOk => Ok(ret),
@@ -154,7 +154,7 @@ impl FK20MultiSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGSe
     }
 
     fn data_availability(&self, p: &KzgPoly) -> Result<Vec<BlstP1>, String> {
-        let mut ret = vec![G1::default(); 2 * p.len() as usize];
+        let mut ret = vec![BlstP1::default(); 2 * p.len() as usize];
         unsafe {
             match da_using_fk20_multi(ret.as_mut_ptr(), p, self, RUN_PARALLEL) {
                 KzgRet::KzgOk => Ok(ret),
@@ -167,7 +167,7 @@ impl FK20MultiSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly, KzgKZGSe
     }
 
     fn data_availability_optimized(&self, p: &KzgPoly) -> Result<Vec<BlstP1>, String> {
-        let mut ret = vec![G1::default(); 2 * p.len() as usize];
+        let mut ret = vec![BlstP1::default(); 2 * p.len() as usize];
         unsafe {
             match fk20_multi_da_opt(ret.as_mut_ptr(), p, self, RUN_PARALLEL) {
                 KzgRet::KzgOk => Ok(ret),

--- a/ckzg/src/kzgsettings.rs
+++ b/ckzg/src/kzgsettings.rs
@@ -70,8 +70,8 @@ impl Default for KzgKZGSettings {
     fn default() -> Self {
         Self {
             fs: &KzgFFTSettings::default(),
-            secret_g1: &mut G1::default(),
-            secret_g2: &mut G2::default(),
+            secret_g1: &mut BlstP1::default(),
+            secret_g2: &mut BlstP2::default(),
             length: 0,
         }
     }
@@ -103,7 +103,7 @@ impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly> for KzgKZGSett
     }
 
     fn commit_to_poly(&self, p: &KzgPoly) -> Result<BlstP1, String> {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         unsafe {
             match commit_to_poly(&mut ret, p, self) {
                 KzgRet::KzgOk => Ok(ret),
@@ -116,7 +116,7 @@ impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly> for KzgKZGSett
     }
 
     fn compute_proof_single(&self, p: &KzgPoly, x: &BlstFr) -> Result<BlstP1, String> {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         unsafe {
             match compute_proof_single(&mut ret, p, x, self) {
                 KzgRet::KzgOk => Ok(ret),
@@ -148,7 +148,7 @@ impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly> for KzgKZGSett
     }
 
     fn compute_proof_multi(&self, p: &KzgPoly, x: &BlstFr, n: usize) -> Result<BlstP1, String> {
-        let mut ret = G1::default();
+        let mut ret = BlstP1::default();
         unsafe {
             match compute_proof_multi(&mut ret, p, x, n as u64, self) {
                 KzgRet::KzgOk => Ok(ret),
@@ -212,8 +212,8 @@ pub fn generate_trusted_setup(len: usize, secret: [u8; 32usize]) -> (Vec<BlstP1>
     let mut s = BlstFr::default();
     unsafe { fr_from_scalar(&mut s, &blst_scalar) };
 
-    let mut s1 = vec![G1::default(); 0];
-    let mut s2 = vec![G2::default(); 0];
+    let mut s1 = vec![BlstP1::default(); 0];
+    let mut s2 = vec![BlstP2::default(); 0];
 
     for _i in 0..len {
         let g1_mul = G1Mul::mul(&G1::generator(), &s_pow);

--- a/ckzg/src/kzgsettings4844.rs
+++ b/ckzg/src/kzgsettings4844.rs
@@ -1,4 +1,4 @@
-use kzg::{FFTSettings, KZGSettings, G1, G2};
+use kzg::{FFTSettings, KZGSettings};
 
 use crate::consts::{BlstP1, BlstP2};
 use crate::fftsettings4844::KzgFFTSettings4844;
@@ -28,8 +28,8 @@ impl Default for KzgKZGSettings4844 {
     fn default() -> Self {
         Self {
             fs: &KzgFFTSettings4844::default(),
-            g1_values: &mut G1::default(),
-            g2_values: &mut G2::default(),
+            g1_values: &mut BlstP1::default(),
+            g2_values: &mut BlstP2::default(),
         }
     }
 }

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -43,9 +43,7 @@ pub trait Fr: Default + Clone {
     fn equals(&self, b: &Self) -> bool;
 }
 
-pub trait G1: Clone {
-    fn default() -> Self;
-
+pub trait G1: Clone + Default {
     fn identity() -> Self;
 
     fn generator() -> Self;
@@ -70,9 +68,7 @@ pub trait G1Mul<Fr>: Clone {
     fn mul(&self, b: &Fr) -> Self;
 }
 
-pub trait G2: Clone {
-    fn default() -> Self;
-
+pub trait G2: Clone + Default {
     fn generator() -> Self;
 
     fn negative_generator() -> Self;

--- a/mcl/kzg/src/trait_implementations/g1.rs
+++ b/mcl/kzg/src/trait_implementations/g1.rs
@@ -3,10 +3,6 @@ use crate::fk20_fft::{G1_GENERATOR, G1_NEGATIVE_GENERATOR};
 use kzg::{G1Mul, G1 as CommonG1};
 
 impl CommonG1 for G1 {
-    fn default() -> Self {
-        G1::zero()
-    }
-
     fn identity() -> Self {
         G1::G1_IDENTITY
     }

--- a/mcl/kzg/src/trait_implementations/g2.rs
+++ b/mcl/kzg/src/trait_implementations/g2.rs
@@ -2,10 +2,6 @@ use crate::data_types::{fr::Fr, g2::G2};
 use kzg::{G2Mul, G2 as CommonG2};
 
 impl CommonG2 for G2 {
-    fn default() -> Self {
-        G2::zero()
-    }
-
     fn generator() -> Self {
         G2::gen()
     }

--- a/zkcrypto/src/eip_4844.rs
+++ b/zkcrypto/src/eip_4844.rs
@@ -38,7 +38,7 @@ pub fn vector_lincomb(vectors: &[Vec<blsScalar>], scalars: &[blsScalar]) -> Vec<
 
 pub fn g1_lincomb(points: &[ZkG1Projective], scalars: &[blsScalar]) -> ZkG1Projective {
     assert!(points.len() == scalars.len());
-    let mut out = G1::default();
+    let mut out = ZkG1Projective::default();
     g1_linear_combination(&mut out, points, scalars, points.len());
     out
 }

--- a/zkcrypto/src/fft_g1.rs
+++ b/zkcrypto/src/fft_g1.rs
@@ -34,7 +34,7 @@ impl FFTG1<ZkG1Projective> for ZkFFTSettings {
         }
 
         let stride = self.max_width / data.len();
-        let mut ret = vec![<ZkG1Projective as G1>::default(); data.len()];
+        let mut ret = vec![ZkG1Projective::default(); data.len()];
 
         let roots = if inverse {
             &self.reverse_roots_of_unity

--- a/zkcrypto/src/kzg_types.rs
+++ b/zkcrypto/src/kzg_types.rs
@@ -217,10 +217,6 @@ pub const G2_NEGATIVE_GENERATOR: ZkG2Projective = ZkG2Projective {
 };
 
 impl G1 for ZkG1Projective {
-    fn default() -> Self {
-        <ZkG1Projective as Default>::default() //istryniau as Default
-    }
-
     fn identity() -> Self {
         G1_IDENTITY
     }
@@ -273,10 +269,6 @@ impl G1Mul<blsScalar> for ZkG1Projective {
 }
 
 impl G2 for ZkG2Projective {
-    fn default() -> Self {
-        <ZkG2Projective as Default>::default()
-    }
-
     fn generator() -> Self {
         G2_GENERATOR
     }


### PR DESCRIPTION
Wanted to derive `Default` on `FsG1` and noticed that I forgot one more place with `Default` during earlier refactoring