### PR TITLE
`no_std` support in `kzg` crate

### DIFF
--- a/blst-from-scratch/Cargo.toml
+++ b/blst-from-scratch/Cargo.toml
@@ -24,6 +24,7 @@ default = [
     "rand",
 ]
 std = [
+    "kzg/std",
     "libc/std",
     "once_cell/std",
     "sha2/std",

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["rand"]
+default = [
+    "rand",
+    "std",
+]
 rand = []
+std = []

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -1,3 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
 pub mod eip_4844;
 
 pub trait Fr: Default + Clone {


### PR DESCRIPTION
When I tried to use `blst_from_scratch` in `no_std` environment, turned out that `kzg` crate needs to be adapted a bit too.