### PR TITLE
Handle EIP4844 proving when challenge is in domain

### DIFF
--- a/blst-from-scratch/src/eip_4844.rs
+++ b/blst-from-scratch/src/eip_4844.rs
@@ -241,6 +241,7 @@ pub fn compute_kzg_proof_rust(p: &FsPoly, x: &FsFr, s: &FsKZGSettings) -> FsG1 {
     while i < q.len() {
         if x.equals(&roots_of_unity[i]) {
             m = i + 1;
+            inverses_in[i]= FsFr::one();
             continue;
         }
         // (p_i - y) / (ω_i - x)

--- a/blst-from-scratch/src/eip_4844.rs
+++ b/blst-from-scratch/src/eip_4844.rs
@@ -242,6 +242,7 @@ pub fn compute_kzg_proof_rust(p: &FsPoly, x: &FsFr, s: &FsKZGSettings) -> FsG1 {
         if x.equals(&roots_of_unity[i]) {
             m = i + 1;
             inverses_in[i]= FsFr::one();
+            i+=1;
             continue;
         }
         // (p_i - y) / (ω_i - x)
@@ -260,11 +261,12 @@ pub fn compute_kzg_proof_rust(p: &FsPoly, x: &FsFr, s: &FsKZGSettings) -> FsG1 {
 
     if m > 0 {
         // ω_m == x
-        q.coeffs[m] = FsFr::zero();
         m -= 1;
+        q.coeffs[m] = FsFr::zero();
         i = 0;
         while i < q.coeffs.len() {
             if i == m {
+                i+=1;
                 continue;
             }
             // (p_i - y) * ω_i / (x * (x - ω_i))
@@ -275,6 +277,10 @@ pub fn compute_kzg_proof_rust(p: &FsPoly, x: &FsFr, s: &FsKZGSettings) -> FsG1 {
         fr_batch_inv(&mut inverses, &inverses_in, q.coeffs.len());
         i = 0;
         while i < q.coeffs.len() {
+            if i == m {
+                i+=1;
+                continue;
+            }
             tmp = p.coeffs[i].sub(&y);
             tmp = tmp.mul(&roots_of_unity[i]);
             tmp = tmp.mul(&inverses[i]);

--- a/kzg-bench/src/tests/eip_4844.rs
+++ b/kzg-bench/src/tests/eip_4844.rs
@@ -271,6 +271,20 @@ pub fn compute_commitment_for_blobs_test<
         "Verification failed"
     );
 
+    //Prove when challenge is in domain
+    let x_in_domain = ts.get_expanded_roots_of_unity_at(1);
+
+    let proof_in_domain = compute_kzg_proof(&mut aggregated_poly, &x_in_domain, &ts);
+
+    // Verify proof
+
+    let y_in_domain = evaluate_polynomial_in_evaluation_form(&aggregated_poly, &x_in_domain, &ts);
+
+    assert!(
+        verify_kzg_proof(&simple_commitment, &x_in_domain, &y_in_domain, &proof_in_domain, &ts),
+        "Simple verification in domain failed"
+    );
+
     let mut x2_bytes: [u8; 32] = rng.gen();
     while x2_bytes == hashed_polynomial_and_commitment {
         x2_bytes = rng.gen();


### PR DESCRIPTION
Issue: `compute_kzg_proof_rust` was hanging for me when `x` was a power of root of unity, which is a common case when KZG is used as vector commitment (like we do at Subspace).
Fix:
- Handled the case when x is inside the evaluation domain (is a power of root of unity) according to what Ethereum does in [PR111](https://github.com/ethereum/c-kzg-4844/pull/111) by setting its inverse to 1
- Fix infinite loops due to missing increments in the same case
- Added test
cc @nazar-pc 