### PR TITLE
refactor: Optimize pairing computation in blst_from_scratch/pairing_verify.

### DIFF
--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -76,6 +76,7 @@ impl FsG2 {
         Self(blst_p2::default())
     }
 
+    #[cfg(feature = "rand")]
     pub fn rand() -> Self {
         let result: FsG2 = G2_GENERATOR;
         result.mul(&FsFr::rand())

--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -2,7 +2,7 @@ use blst::{
     blst_fp2, blst_p2, blst_p2_add_or_double, blst_p2_cneg, blst_p2_double, blst_p2_is_equal,
     blst_p2_mult, blst_scalar, blst_scalar_from_fr,
 };
-use kzg::{G2Mul, G2};
+use kzg::{Fr, G2Mul, G2};
 
 use crate::consts::{G2_GENERATOR, G2_NEGATIVE_GENERATOR};
 use crate::types::fr::FsFr;
@@ -74,5 +74,10 @@ impl FsG2 {
 
     pub fn default() -> Self {
         Self(blst_p2::default())
+    }
+
+    pub fn rand() -> Self {
+        let result: FsG2 = G2_GENERATOR;
+        result.mul(&FsFr::rand())
     }
 }

--- a/blst-from-scratch/tests/kzg_proofs.rs
+++ b/blst-from-scratch/tests/kzg_proofs.rs
@@ -1,5 +1,10 @@
 #[cfg(test)]
 mod tests {
+    use blst::{
+        blst_final_exp, blst_fp12, blst_fp12_mul, blst_miller_loop, blst_p1_affine, blst_p1_cneg,
+        blst_p1_to_affine, blst_p2_affine, blst_p2_to_affine, Pairing,
+    };
+    use kzg::G1;
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
     };
@@ -38,5 +43,56 @@ mod tests {
         proof_multi::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
             &generate_trusted_setup,
         );
+    }
+
+    // This aims at showing that the use of the blst::Pairing engine in pairings_verify
+    // has the desired semantics.
+    fn og_pairings_verify() {
+        let a1 = FsG1::rand();
+        let a2 = FsG2::rand();
+        let b1 = FsG1::rand();
+        let b2 = FsG2::rand();
+
+        let mut loop0 = blst_fp12::default();
+        let mut loop1 = blst_fp12::default();
+        let mut gt_point = blst_fp12::default();
+
+        let mut aa1 = blst_p1_affine::default();
+        let mut bb1 = blst_p1_affine::default();
+
+        let mut aa2 = blst_p2_affine::default();
+        let mut bb2 = blst_p2_affine::default();
+
+        // As an optimisation, we want to invert one of the pairings,
+        // so we negate one of the points.
+        let mut a1neg: FsG1 = a1;
+        unsafe {
+            blst_p1_cneg(&mut a1neg.0, true);
+            blst_p1_to_affine(&mut aa1, &a1neg.0);
+
+            blst_p1_to_affine(&mut bb1, &b1.0);
+            blst_p2_to_affine(&mut aa2, &a2.0);
+            blst_p2_to_affine(&mut bb2, &b2.0);
+
+            blst_miller_loop(&mut loop0, &aa2, &aa1);
+            blst_miller_loop(&mut loop1, &bb2, &bb1);
+
+            blst_fp12_mul(&mut gt_point, &loop0, &loop1);
+            blst_final_exp(&mut gt_point, &gt_point);
+
+            let dst = [0u8; 3];
+            let mut pairing_blst = Pairing::new(false, &dst);
+            pairing_blst.raw_aggregate(&aa2, &aa1);
+            pairing_blst.raw_aggregate(&bb2, &bb1);
+
+            assert_eq!(gt_point, pairing_blst.as_fp12().final_exp());
+        }
+    }
+
+    #[test]
+    pub fn test_pairings_verify() {
+        for _i in 0..100 {
+            og_pairings_verify();
+        }
     }
 }

--- a/blst-from-scratch/tests/kzg_proofs.rs
+++ b/blst-from-scratch/tests/kzg_proofs.rs
@@ -47,6 +47,7 @@ mod tests {
 
     // This aims at showing that the use of the blst::Pairing engine in pairings_verify
     // has the desired semantics.
+    #[cfg(feature = "rand")]
     fn og_pairings_verify() {
         let a1 = FsG1::rand();
         let a2 = FsG2::rand();
@@ -89,6 +90,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "rand")]
     #[test]
     pub fn test_pairings_verify() {
         for _i in 0..100 {


### PR DESCRIPTION
- Add `rand()` method to FsG2
- Add test for `pairings_verify` that checks `blst::Pairing semantics`
- Replace pairing computation with more efficient implementation in kzg_proofs.rs

BLST offers an efficient `Pairing` engine which mutualizes the miller loop computation.

The API for this binding, `blst_miller_loop_n` is alas not public, but there is a public `Pairing` engine built for BLS12-381 signatures that is available and maps to this API. All it requires is passing a dst, for which a dummy parameter is chosen.

Result on my machine (using the eip_4844 benchmark):
```
verify_kzg_proof        time:   [809.05 µs 815.95 µs 826.04 µs]
                        change: [-13.766% -9.1251% -6.1879%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
  ```

See also https://github.com/supranational/blst/issues/136