### PR TITLE
Parallel pippenger from blst

### DIFF
--- a/blst-from-scratch/src/kzg_proofs.rs
+++ b/blst-from-scratch/src/kzg_proofs.rs
@@ -6,14 +6,19 @@ use blst::{
     blst_fp12_is_one, blst_p1, blst_p1_affine, blst_p1_cneg, blst_p1_to_affine, blst_p2_affine,
     blst_p2_to_affine, p1_affines, Pairing,
 };
+use kzg::{G1Mul, G1};
 
 use crate::types::fr::FsFr;
 use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 
 pub fn g1_linear_combination(out: &mut FsG1, points: &[FsG1], scalars: &[FsFr], len: usize) {
-    if len == 0 {
+    if len < 8 {
         *out = FsG1::default();
+        for i in 0..len {
+            let tmp = points[i].mul(&scalars[i]);
+            *out = out.add_or_dbl(&tmp);
+        }
         return;
     }
 

--- a/blst-from-scratch/src/kzg_proofs.rs
+++ b/blst-from-scratch/src/kzg_proofs.rs
@@ -1,63 +1,32 @@
 extern crate alloc;
 
-use alloc::vec;
 use alloc::vec::Vec;
-use core::ptr;
 
 use blst::{
-    blst_fp12_is_one, blst_p1, blst_p1_affine, blst_p1_cneg, blst_p1_to_affine,
-    blst_p1s_mult_pippenger, blst_p1s_mult_pippenger_scratch_sizeof, blst_p1s_to_affine,
-    blst_p2_affine, blst_p2_to_affine, blst_scalar, limb_t, Pairing,
+    blst_fp12_is_one, blst_p1, blst_p1_affine, blst_p1_cneg, blst_p1_to_affine, blst_p2_affine,
+    blst_p2_to_affine, p1_affines, Pairing,
 };
-use kzg::{G1Mul, G1};
 
-use crate::consts::G1_IDENTITY;
 use crate::types::fr::FsFr;
 use crate::types::g1::FsG1;
 use crate::types::g2::FsG2;
 
-pub fn g1_linear_combination(out: &mut FsG1, p: &[FsG1], coeffs: &[FsFr], len: usize) {
-    if len < 8 {
-        // Direct approach
-        let mut tmp;
-        *out = G1_IDENTITY;
-        for i in 0..len {
-            tmp = p[i].mul(&coeffs[i]);
-            *out = out.add_or_dbl(&tmp);
-        }
-    } else {
-        let mut scratch: Vec<u8>;
-        unsafe {
-            scratch = vec![0u8; blst_p1s_mult_pippenger_scratch_sizeof(len) as usize];
-        }
-
-        let mut p_affine = vec![blst_p1_affine::default(); len];
-        let mut scalars = vec![blst_scalar::default(); len];
-
-        let p_arg: [*const blst_p1; 2] = [&p[0].0, ptr::null()];
-        unsafe {
-            blst_p1s_to_affine(p_affine.as_mut_ptr(), p_arg.as_ptr(), len);
-        }
-
-        for i in 0..len {
-            scalars[i] = blst_scalar {
-                b: coeffs[i].to_scalar(),
-            };
-        }
-
-        let scalars_arg: [*const blst_scalar; 2] = [scalars.as_ptr(), ptr::null()];
-        let points_arg: [*const blst_p1_affine; 2] = [p_affine.as_ptr(), ptr::null()];
-        unsafe {
-            blst_p1s_mult_pippenger(
-                &mut out.0,
-                points_arg.as_ptr(),
-                len,
-                scalars_arg.as_ptr() as *const *const u8,
-                256,
-                scratch.as_mut_ptr() as *mut limb_t,
-            );
-        }
+pub fn g1_linear_combination(out: &mut FsG1, points: &[FsG1], scalars: &[FsFr], len: usize) {
+    if len == 0 {
+        *out = FsG1::default();
+        return;
     }
+
+    let points = unsafe { core::slice::from_raw_parts(points.as_ptr() as *const blst_p1, len) };
+    let points = p1_affines::from(points);
+
+    let mut scalar_bytes: Vec<u8> = Vec::with_capacity(len * 32);
+    for bytes in scalars.iter().map(|b| b.to_scalar()) {
+        scalar_bytes.extend_from_slice(&bytes);
+    }
+
+    let res = points.mult(scalar_bytes.as_slice(), 255);
+    *out = FsG1(res)
 }
 
 pub fn pairings_verify(a1: &FsG1, a2: &FsG2, b1: &FsG1, b2: &FsG2) -> bool {

--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -2,7 +2,9 @@ use blst::{
     blst_fp2, blst_p2, blst_p2_add_or_double, blst_p2_cneg, blst_p2_double, blst_p2_is_equal,
     blst_p2_mult, blst_scalar, blst_scalar_from_fr,
 };
-use kzg::{Fr, G2Mul, G2};
+#[cfg(feature = "std")]
+use kzg::Fr;
+use kzg::{G2Mul, G2};
 
 use crate::consts::{G2_GENERATOR, G2_NEGATIVE_GENERATOR};
 use crate::types::fr::FsFr;


### PR DESCRIPTION
I found out that there already exists a Pippenger's implementation for [supranational/blst rust binding](https://github.com/supranational/blst/blob/a7fd1f584d26b0ae6cdc427976ea1d8980f7e15d/bindings/rust/src/pippenger.rs#L93-L238), which appears to use buckets (a large grid for storing the results) and a thread pool for parallelization.

Implementing it achieved the following results:

| Benchmark | Old | New | Speedup |
|--------|--------|--------|--------|
| blob_to_kzg_commitment | 54.145 ms | 17.132 ms | 3.16x |
| compute_kzg_proof | 65.029 ms | 26.509 ms | 2.45x |
| compute_blob_kzg_proof | 65.680 ms | 27.342 ms | 2.40x |
| bench_commit_to_poly | 348.61 ms | 97.402 ms | 3.58x | 

However, there seemed to be a little caveat that it didn't work for certain lengths:

* 0 --> panics with message `scalars length mismatch`
* 1 --> fails the `test_fk_multi_chunk_len_1_512` test
* 6 --> fails 1 out of 222 [test vectors](https://github.com/ethereum/c-kzg-4844/tree/main/tests/verify_blob_kzg_proof_batch/small)

So we opted out for a naive approach for lengths less than 8.

Related issue: #202