### PR TITLE
Switch to latest release of `ssz_rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
  "kzg",
  "rand",
  "sha2 0.10.6",
- "ssz-rs",
+ "ssz_rs",
 ]
 
 [[package]]
@@ -1209,23 +1209,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz-rs"
+name = "ssz_rs"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs.git?rev=688a82389f60ed68c10404417c1f7f442ba748a1#688a82389f60ed68c10404417c1f7f442ba748a1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f923762d556417668b192ac2fdc9827ea21e6df011d8a0a7e68f3d5da095a675"
 dependencies = [
  "bitvec",
  "hex",
  "num-bigint",
  "serde",
  "sha2 0.9.9",
- "ssz-rs-derive",
+ "ssz_rs_derive",
  "thiserror",
 ]
 
 [[package]]
-name = "ssz-rs-derive"
+name = "ssz_rs_derive"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs.git?rev=688a82389f60ed68c10404417c1f7f442ba748a1#688a82389f60ed68c10404417c1f7f442ba748a1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c679ebd9c1ceeb0f9e5b839952b4a71bfe35a791b431ef7b3ee0b71b7588b565"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kzg-bench/Cargo.toml
+++ b/kzg-bench/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 kzg = { path = '../kzg' }
 rand = "0.8.5"
 criterion = "0.4.0"
-# TODO: Unreleased 0.8.0, switch to upstream once released, see https://github.com/ralexstokes/ssz-rs/issues/51
-ssz-rs = { version = "0.8.0", git = "https://github.com/ralexstokes/ssz-rs.git", rev = "688a82389f60ed68c10404417c1f7f442ba748a1" }
+ssz_rs = "0.8.0"
 sha2 = "0.10.6"
 
 [features]


### PR DESCRIPTION
https://github.com/ralexstokes/ssz-rs/issues/51 was finally resolved and there is no need to use git revision anymore