### PR TITLE
Idiomatic Rust refactoring

### DIFF
--- a/blst-from-scratch/src/eip_4844.rs
+++ b/blst-from-scratch/src/eip_4844.rs
@@ -214,8 +214,8 @@ pub fn verify_kzg_proof_batch(
     ts: &FsKZGSettings,
 ) -> bool {
     let n = commitments_g1.len();
-    let mut c_minus_y: Vec<FsG1> = Vec::new();
-    let mut r_times_z: Vec<FsFr> = Vec::new();
+    let mut c_minus_y: Vec<FsG1> = Vec::with_capacity(n);
+    let mut r_times_z: Vec<FsFr> = Vec::with_capacity(n);
 
     // Compute the random lincomb challenges
     let r_powers = compute_r_powers(commitments_g1, zs_fr, ys_fr, proofs_g1);
@@ -478,8 +478,8 @@ fn compute_challenges_and_evaluate_polynomial(
     commitments_g1: &[FsG1],
     ts: &FsKZGSettings,
 ) -> (Vec<FsFr>, Vec<FsFr>) {
-    let mut evaluation_challenges_fr = Vec::new();
-    let mut ys_fr = Vec::new();
+    let mut evaluation_challenges_fr = Vec::with_capacity(blobs.len());
+    let mut ys_fr = Vec::with_capacity(blobs.len());
 
     for i in 0..blobs.len() {
         let polynomial = blob_to_polynomial_rust(&blobs[i]);
@@ -879,9 +879,9 @@ pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     n: usize,
     s: &CKZGSettings,
 ) -> C_KZG_RET {
-    let mut deserialized_blobs: Vec<Vec<FsFr>> = Vec::new();
-    let mut commitments_g1: Vec<FsG1> = Vec::new();
-    let mut proofs_g1: Vec<FsG1> = Vec::new();
+    let mut deserialized_blobs: Vec<Vec<FsFr>> = Vec::with_capacity(n);
+    let mut commitments_g1: Vec<FsG1> = Vec::with_capacity(n);
+    let mut proofs_g1: Vec<FsG1> = Vec::with_capacity(n);
 
     let raw_blobs = core::slice::from_raw_parts(blobs, n);
     let raw_commitments = core::slice::from_raw_parts(commitments_bytes, n);

--- a/blst-from-scratch/src/recovery.rs
+++ b/blst-from-scratch/src/recovery.rs
@@ -19,31 +19,41 @@ pub fn scale_poly(p: &mut [FsFr], len_p: usize) {
     let factors = INVERSE_FACTORS.get_or_init(|| {
         let scale_factor = FsFr::from_u64(SCALE_FACTOR);
         let inv_factor = FsFr::inverse(&scale_factor);
-        let mut temp: Vec<FsFr> = vec![FsFr::one()];
+        let mut temp = Vec::with_capacity(65536);
+        temp.push(FsFr::one());
         for i in 1..65536 {
             temp.push(temp[i - 1].mul(&inv_factor));
         }
         temp
     });
 
-    for i in 1..len_p {
-        p[i] = p[i].mul(&factors[i]);
-    }
+    p.iter_mut()
+        .zip(factors)
+        .take(len_p)
+        .skip(1)
+        .for_each(|(p, factor)| {
+            *p = p.mul(factor);
+        });
 }
 
 pub fn unscale_poly(p: &mut [FsFr], len_p: usize) {
     let factors = UNSCALE_FACTOR_POWERS.get_or_init(|| {
         let scale_factor = FsFr::from_u64(SCALE_FACTOR);
-        let mut temp: Vec<FsFr> = vec![FsFr::one()];
+        let mut temp = Vec::with_capacity(65536);
+        temp.push(FsFr::one());
         for i in 1..65536 {
             temp.push(temp[i - 1].mul(&scale_factor));
         }
         temp
     });
 
-    for i in 1..len_p {
-        p[i] = p[i].mul(&factors[i]);
-    }
+    p.iter_mut()
+        .zip(factors)
+        .take(len_p)
+        .skip(1)
+        .for_each(|(p, factor)| {
+            *p = p.mul(factor);
+        });
 }
 
 pub fn recover_poly_from_samples(

--- a/blst-from-scratch/src/types/fk20_multi_settings.rs
+++ b/blst-from-scratch/src/types/fk20_multi_settings.rs
@@ -62,34 +62,35 @@ impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
         let n = n2 / 2;
         let k = n / chunk_len;
 
-        let mut ext_fft_files = Vec::new();
-
-        for offset in 0..chunk_len {
-            let mut x = Vec::new();
-
-            let mut start = 0;
-            if n >= chunk_len + 1 + offset {
-                start = n - chunk_len - 1 - offset;
-            }
-
-            let mut i = 0;
-            let mut j = start;
-
-            while i + 1 < k {
-                x.push(ks.secret_g1[j as usize]);
-
-                i += 1;
-
-                if j >= chunk_len {
-                    j -= chunk_len;
-                } else {
-                    j = 0;
+        let mut ext_fft_files = Vec::with_capacity(chunk_len);
+        {
+            let mut x = Vec::with_capacity(k);
+            for offset in 0..chunk_len {
+                let mut start = 0;
+                if n >= chunk_len + 1 + offset {
+                    start = n - chunk_len - 1 - offset;
                 }
-            }
-            x.push(FsG1::identity());
 
-            let ext_fft_file = ks.fs.toeplitz_part_1(&x);
-            ext_fft_files.push(ext_fft_file);
+                let mut i = 0;
+                let mut j = start;
+
+                while i + 1 < k {
+                    x.push(ks.secret_g1[j as usize]);
+
+                    i += 1;
+
+                    if j >= chunk_len {
+                        j -= chunk_len;
+                    } else {
+                        j = 0;
+                    }
+                }
+                x.push(FsG1::identity());
+
+                let ext_fft_file = ks.fs.toeplitz_part_1(&x);
+                x.clear();
+                ext_fft_files.push(ext_fft_file);
+            }
         }
 
         let ret = Self {

--- a/blst-from-scratch/src/types/fk20_single_settings.rs
+++ b/blst-from-scratch/src/types/fk20_single_settings.rs
@@ -35,13 +35,14 @@ impl FK20SingleSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings>
             return Err(String::from("n2 must be greater than or equal to 2"));
         }
 
-        let mut x = Vec::new();
+        let mut x = Vec::with_capacity(n);
         for i in 0..n - 1 {
             x.push(kzg_settings.secret_g1[n - 2 - i]);
         }
         x.push(FsG1::identity());
 
         let x_ext_fft = kzg_settings.fs.toeplitz_part_1(&x);
+        drop(x);
         let kzg_settings = kzg_settings.clone();
 
         let ret = Self {

--- a/blst-from-scratch/src/types/g2.rs
+++ b/blst-from-scratch/src/types/g2.rs
@@ -2,7 +2,7 @@ use blst::{
     blst_fp2, blst_p2, blst_p2_add_or_double, blst_p2_cneg, blst_p2_double, blst_p2_is_equal,
     blst_p2_mult, blst_scalar, blst_scalar_from_fr,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "rand")]
 use kzg::Fr;
 use kzg::{G2Mul, G2};
 

--- a/blst-from-scratch/src/types/kzg_settings.rs
+++ b/blst-from-scratch/src/types/kzg_settings.rs
@@ -93,7 +93,9 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly> for FsKZGSettings {
         }
 
         // Construct x^n - x0^n = (x - x0.w^0)(x - x0.w^1)...(x - x0.w^(n-1))
-        let mut divisor: FsPoly = FsPoly { coeffs: Vec::new() };
+        let mut divisor = FsPoly {
+            coeffs: Vec::with_capacity(n),
+        };
 
         // -(x0^n)
         let x_pow_n = x0.pow(n);

--- a/blst-from-scratch/src/utils.rs
+++ b/blst-from-scratch/src/utils.rs
@@ -42,8 +42,8 @@ pub fn generate_trusted_setup(n: usize, secret: [u8; 32usize]) -> (Vec<FsG1>, Ve
     let s = FsFr::hash_to_bls_field(secret);
     let mut s_pow = Fr::one();
 
-    let mut s1 = Vec::new();
-    let mut s2 = Vec::new();
+    let mut s1 = Vec::with_capacity(n);
+    let mut s2 = Vec::with_capacity(n);
 
     for _ in 0..n {
         s1.push(G1_GENERATOR.mul(&s_pow));

--- a/kzg-bench/src/benches/recover.rs
+++ b/kzg-bench/src/benches/recover.rs
@@ -1,4 +1,4 @@
-use criterion::Criterion;
+use criterion::{black_box, Criterion};
 use kzg::{FFTFr, FFTSettings, Fr, Poly, PolyRecover};
 use rand::Rng;
 use std::convert::TryInto;
@@ -41,7 +41,7 @@ pub fn bench_recover<
     let id = format!("bench_recover scale: '{}'", BENCH_SCALE);
     c.bench_function(&id, move |b| {
         b.iter(|| {
-            TPolyRecover::recover_poly_from_samples(&samples, &fs).unwrap();
+            TPolyRecover::recover_poly_from_samples(black_box(&samples), black_box(&fs)).unwrap();
         })
     });
 }


### PR DESCRIPTION
I was looking at recovery code trying to find a way to optimize it. In the end I went through a large chunk of the code, replacing manual indexing of vectors with idiomatic iterators and pre-allocating vectors with known size to avoid re-allocations.

End result isn't impressive, from my testing improvement is 1-5%, benchmark is very noisy, I blame it on heterogeneous cores of my 13900K processor. But it is faster in general.

One question I have is whether `recover_poly_from_samples` should be removed from `recovery.rs` and its changes moved into `FsPoly::recover_poly_from_samples` (there is some extra parallelization there for instance, but for the most part functions are just duplicates of each other).