### PR TITLE
Fix `no_std` support

### DIFF
--- a/blst-from-scratch/Cargo.toml
+++ b/blst-from-scratch/Cargo.toml
@@ -11,7 +11,7 @@ libc = { version = "0.2.137", default-features = false }
 once_cell = { version = "1.4.0", features = ["critical-section"], default-features = false }
 rand = { version = "0.8.4", optional = true }
 rayon = { version = "1.5.1", optional = true }
-num_cpus = "1.15.0"
+num_cpus = { version = "1.15.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.4.0"
@@ -32,7 +32,10 @@ rand = [
     "dep:rand",
     "kzg/rand",
 ]
-parallel = ["dep:rayon"]
+parallel = [
+    "dep:rayon",
+    "dep:num_cpus",
+]
 minimal-spec = ["kzg/minimal-spec", "kzg-bench/minimal-spec"]
 
 [[bench]]

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 blst = { 'git' = 'https://github.com/supranational/blst.git' }
-sha2 = "0.10.6"
+sha2 = { version = "0.10.6", default-features = false }
 
 [features]
 default = [


### PR DESCRIPTION
Regressed with recent changes, the most annoying thing with `wasm32-unknown-unknown` is that it does have `std`, it is just incomplete