### PR TITLE
New benchmarks and improved G1 linear combination

### DIFF
--- a/Arkworks/Cargo.toml
+++ b/Arkworks/Cargo.toml
@@ -59,3 +59,7 @@ harness = false
 [[bench]]
 name = "eip_4844"
 harness = false
+
+[[bench]]
+name = "lincomb"
+harness = false

--- a/Arkworks/benches/kzg.rs
+++ b/Arkworks/benches/kzg.rs
@@ -1,18 +1,28 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::kzg::kzg_proof;
+use kzg_bench::benches::kzg::{commit_to_poly, compute_proof_single};
 
 use arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
 use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
 use arkworks::utils::PolyData;
 
-fn kzg_proof_(c: &mut Criterion) {
-    kzg_proof::<FsFr, ArkG1, ArkG2, PolyData, FFTSettings, KZGSettings>(c, &generate_trusted_setup);
+fn commit_to_poly_(c: &mut Criterion) {
+    commit_to_poly::<FsFr, ArkG1, ArkG2, PolyData, FFTSettings, KZGSettings>(
+        c,
+        &generate_trusted_setup,
+    );
+}
+
+fn compute_proof_single_(c: &mut Criterion) {
+    compute_proof_single::<FsFr, ArkG1, ArkG2, PolyData, FFTSettings, KZGSettings>(
+        c,
+        &generate_trusted_setup,
+    );
 }
 
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = kzg_proof_
+    targets = commit_to_poly_, compute_proof_single_
 }
 
 criterion_main!(benches);

--- a/Arkworks/benches/lincomb.rs
+++ b/Arkworks/benches/lincomb.rs
@@ -1,0 +1,16 @@
+use arkworks::fft_g1::g1_linear_combination;
+use arkworks::kzg_types::{ArkG1, FsFr};
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::lincomb::bench_g1_lincomb;
+
+fn bench_g1_lincomb_(c: &mut Criterion) {
+    bench_g1_lincomb::<FsFr, ArkG1>(c, &g1_linear_combination);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_g1_lincomb_
+}
+
+criterion_main!(benches);

--- a/Arkworks/src/fft_g1.rs
+++ b/Arkworks/src/fft_g1.rs
@@ -11,6 +11,11 @@ use blst::{blst_fp, blst_p1};
 use kzg::G1Mul;
 use kzg::{Fr, FFTG1, G1};
 
+#[cfg(feature = "parallel")]
+use rayon::iter::IntoParallelIterator;
+#[cfg(feature = "parallel")]
+use rayon::iter::ParallelIterator;
+
 pub const G1_NEGATIVE_GENERATOR: blst_p1 = blst_p1 {
     x: blst_fp {
         l: [

--- a/blst-from-scratch/Cargo.toml
+++ b/blst-from-scratch/Cargo.toml
@@ -69,3 +69,7 @@ harness = false
 [[bench]]
 name = "eip_4844"
 harness = false
+
+[[bench]]
+name = "lincomb"
+harness = false

--- a/blst-from-scratch/benches/kzg.rs
+++ b/blst-from-scratch/benches/kzg.rs
@@ -6,16 +6,26 @@ use blst_from_scratch::types::kzg_settings::FsKZGSettings;
 use blst_from_scratch::types::poly::FsPoly;
 use blst_from_scratch::utils::generate_trusted_setup;
 use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::kzg::kzg_proof;
+use kzg_bench::benches::kzg::{commit_to_poly, compute_proof_single};
 
-fn kzg_proof_(c: &mut Criterion) {
-    kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(c, &generate_trusted_setup)
+fn commit_to_poly_(c: &mut Criterion) {
+    commit_to_poly::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+        c,
+        &generate_trusted_setup,
+    )
+}
+
+fn compute_proof_single_(c: &mut Criterion) {
+    compute_proof_single::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+        c,
+        &generate_trusted_setup,
+    )
 }
 
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = kzg_proof_
+    targets = commit_to_poly_, compute_proof_single_
 }
 
 criterion_main!(benches);

--- a/blst-from-scratch/benches/lincomb.rs
+++ b/blst-from-scratch/benches/lincomb.rs
@@ -1,0 +1,17 @@
+use blst_from_scratch::kzg_proofs::g1_linear_combination;
+use blst_from_scratch::types::fr::FsFr;
+use blst_from_scratch::types::g1::FsG1;
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::lincomb::bench_g1_lincomb;
+
+fn bench_g1_lincomb_(c: &mut Criterion) {
+    bench_g1_lincomb::<FsFr, FsG1>(c, &g1_linear_combination);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_g1_lincomb_
+}
+
+criterion_main!(benches);

--- a/ckzg/benches/kzg.rs
+++ b/ckzg/benches/kzg.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::kzg::kzg_proof;
+use kzg_bench::benches::kzg::commit_to_poly;
 
 use ckzg::consts::{BlstP1, BlstP2};
 use ckzg::fftsettings::KzgFFTSettings;
@@ -7,8 +7,8 @@ use ckzg::finite::BlstFr;
 use ckzg::kzgsettings::{generate_trusted_setup, KzgKZGSettings};
 use ckzg::poly::KzgPoly;
 
-fn kzg_proof_(c: &mut Criterion) {
-    kzg_proof::<BlstFr, BlstP1, BlstP2, KzgPoly, KzgFFTSettings, KzgKZGSettings>(
+fn commit_to_poly_(c: &mut Criterion) {
+    commit_to_poly::<BlstFr, BlstP1, BlstP2, KzgPoly, KzgFFTSettings, KzgKZGSettings>(
         c,
         &generate_trusted_setup,
     );
@@ -17,7 +17,7 @@ fn kzg_proof_(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = kzg_proof_
+    targets = commit_to_poly_
 }
 
 criterion_main!(benches);

--- a/kzg-bench/src/benches/lincomb.rs
+++ b/kzg-bench/src/benches/lincomb.rs
@@ -1,0 +1,21 @@
+use criterion::Criterion;
+use kzg::{Fr, G1};
+
+#[allow(clippy::type_complexity)]
+pub fn bench_g1_lincomb<TFr: Fr + Copy, TG1: G1 + Copy>(
+    c: &mut Criterion,
+    g1_linear_combination: &dyn Fn(&mut TG1, &[TG1], &[TFr], usize),
+) {
+    const NUM_POINTS: usize = 4096;
+
+    let points = [TG1::rand(); NUM_POINTS];
+    let scalars = [TFr::rand(); NUM_POINTS];
+
+    let id = format!("bench_g1_lincomb points: '{}'", NUM_POINTS);
+    c.bench_function(&id, |b| {
+        b.iter(|| {
+            let mut out = TG1::default();
+            g1_linear_combination(&mut out, points.as_slice(), scalars.as_slice(), NUM_POINTS)
+        })
+    });
+}

--- a/kzg-bench/src/benches/mod.rs
+++ b/kzg-bench/src/benches/mod.rs
@@ -3,6 +3,7 @@ pub mod eip_4844;
 pub mod fft;
 pub mod fk20;
 pub mod kzg;
+pub mod lincomb;
 pub mod poly;
 pub mod recover;
 pub mod zero_poly;

--- a/mcl/kzg-bench/Cargo.toml
+++ b/mcl/kzg-bench/Cargo.toml
@@ -48,6 +48,10 @@ harness = false
 name = "shared_eip_4844"
 harness = false
 
+[[bench]]
+name = "shared_lincomb"
+harness = false
+
 #[[bench]]
 #name = "bench_fft"
 #harness = false

--- a/mcl/kzg-bench/benches/shared_kzg_proof.rs
+++ b/mcl/kzg-bench/benches/shared_kzg_proof.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::kzg::kzg_proof;
+use kzg_bench::benches::kzg::{commit_to_poly, compute_proof_single};
 use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
 use mcl_rust::fk20_fft::FFTSettings;
 use mcl_rust::kzg10::Polynomial;
@@ -7,9 +7,17 @@ use mcl_rust::kzg_settings::KZGSettings;
 use mcl_rust::mcl_methods::init;
 use mcl_rust::CurveType;
 
-fn kzg_proof_(c: &mut Criterion) {
+fn commit_to_poly_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));
-    kzg_proof::<Fr, G1, G2, Polynomial, FFTSettings, KZGSettings>(
+    commit_to_poly::<Fr, G1, G2, Polynomial, FFTSettings, KZGSettings>(
+        c,
+        &KZGSettings::generate_trusted_setup,
+    );
+}
+
+fn compute_proof_single_(c: &mut Criterion) {
+    assert!(init(CurveType::BLS12_381));
+    compute_proof_single::<Fr, G1, G2, Polynomial, FFTSettings, KZGSettings>(
         c,
         &KZGSettings::generate_trusted_setup,
     );
@@ -18,7 +26,7 @@ fn kzg_proof_(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = kzg_proof_
+    targets = commit_to_poly_, compute_proof_single_
 }
 
 criterion_main!(benches);

--- a/mcl/kzg-bench/benches/shared_lincomb.rs
+++ b/mcl/kzg-bench/benches/shared_lincomb.rs
@@ -1,0 +1,19 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::lincomb::bench_g1_lincomb;
+use mcl_rust::data_types::fr::Fr;
+use mcl_rust::data_types::g1::{g1_linear_combination, G1};
+use mcl_rust::mcl_methods::init;
+use mcl_rust::CurveType;
+
+fn bench_g1_lincomb_(c: &mut Criterion) {
+    assert!(init(CurveType::BLS12_381));
+    bench_g1_lincomb::<Fr, G1>(c, &g1_linear_combination);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_g1_lincomb_
+}
+
+criterion_main!(benches);

--- a/mcl/kzg/src/data_types/g1.rs
+++ b/mcl/kzg/src/data_types/g1.rs
@@ -43,7 +43,7 @@ pub fn g1_linear_combination(out: &mut G1, points: &[G1], scalars: &[Fr], len: u
         *out = (0..len)
             .into_par_iter()
             .map(|i| points[i] * &scalars[i])
-            .reduce(|| G1::default(), |mut acc, tmp| acc.add_or_dbl(&tmp));
+            .reduce(G1::default, |mut acc, tmp| acc.add_or_dbl(&tmp));
     }
 
     #[cfg(not(feature = "parallel"))]

--- a/zkcrypto/Cargo.toml
+++ b/zkcrypto/Cargo.toml
@@ -58,3 +58,7 @@ harness = false
 [[bench]]
 name = "eip_4844"
 harness = false
+
+[[bench]]
+name = "lincomb"
+harness = false

--- a/zkcrypto/benches/kzg.rs
+++ b/zkcrypto/benches/kzg.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::kzg::kzg_proof;
+use kzg_bench::benches::kzg::{commit_to_poly, compute_proof_single};
 
 use zkcrypto::fftsettings::ZkFFTSettings;
 use zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
@@ -7,17 +7,28 @@ use zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
 use zkcrypto::poly::ZPoly;
 use zkcrypto::zkfr::blsScalar;
 
-fn kzg_proof_(c: &mut Criterion) {
-    kzg_proof::<blsScalar, ZkG1Projective, ZkG2Projective, ZPoly, ZkFFTSettings, KZGSettings>(
+fn commit_to_poly_(c: &mut Criterion) {
+    commit_to_poly::<blsScalar, ZkG1Projective, ZkG2Projective, ZPoly, ZkFFTSettings, KZGSettings>(
         c,
         &generate_trusted_setup,
     )
 }
 
+fn compute_proof_single_(c: &mut Criterion) {
+    compute_proof_single::<
+        blsScalar,
+        ZkG1Projective,
+        ZkG2Projective,
+        ZPoly,
+        ZkFFTSettings,
+        KZGSettings,
+    >(c, &generate_trusted_setup)
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = kzg_proof_
+    targets = commit_to_poly_, compute_proof_single_
 }
 
 criterion_main!(benches);

--- a/zkcrypto/benches/lincomb.rs
+++ b/zkcrypto/benches/lincomb.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::lincomb::bench_g1_lincomb;
+use zkcrypto::curve::multiscalar_mul::msm_variable_base;
+use zkcrypto::kzg_types::ZkG1Projective;
+use zkcrypto::zkfr::blsScalar;
+
+fn g1_linear_combination(
+    out: &mut ZkG1Projective,
+    points: &[ZkG1Projective],
+    scalars: &[blsScalar],
+    _len: usize,
+) {
+    *out = msm_variable_base(points, scalars);
+}
+
+fn bench_g1_lincomb_(c: &mut Criterion) {
+    bench_g1_lincomb::<blsScalar, ZkG1Projective>(c, &g1_linear_combination);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_g1_lincomb_
+}
+
+criterion_main!(benches);


### PR DESCRIPTION
- New benchmarks: `compute_proof_single` and `g1_lincomb`
- Arkworks: use parallel iterators in G1 linear combination
- Mcl: naive parallel approach for G1 linear combination