### PR TITLE
Improve recovery performance

### DIFF
--- a/Arkworks/src/zero_poly.rs
+++ b/Arkworks/src/zero_poly.rs
@@ -113,7 +113,7 @@ impl ZeroPoly<BlstFr, PolyData> for FFTSettings {
             return Err(String::from("Domain size must be a power of 2"));
         }
 
-        let degree_of_partial = 64;
+        let degree_of_partial = 256;
         let missing_per_partial = degree_of_partial - 1;
         let domain_stride = self.max_width as usize / length;
         let mut partial_count =

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "once_cell",
  "rand",
  "rayon",
+ "smallvec",
 ]
 
 [[package]]
@@ -1180,6 +1181,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.6",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "static_assertions"

--- a/blst-from-scratch/Cargo.toml
+++ b/blst-from-scratch/Cargo.toml
@@ -8,10 +8,11 @@ edition = "2021"
 blst = { 'git' = 'https://github.com/supranational/blst.git' }
 kzg = { path = "../kzg", default-features = false }
 libc = { version = "0.2.137", default-features = false }
+num_cpus = { version = "1.15.0", optional = true }
 once_cell = { version = "1.4.0", features = ["critical-section"], default-features = false }
 rand = { version = "0.8.4", optional = true }
 rayon = { version = "1.5.1", optional = true }
-num_cpus = { version = "1.15.0", optional = true }
+smallvec = { version = "1.10.0", features = ["const_generics"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/blst-from-scratch/src/fft_fr.rs
+++ b/blst-from-scratch/src/fft_fr.rs
@@ -92,9 +92,7 @@ impl FFTFr<FsFr> for FsFFTSettings {
 
         if inverse {
             let inv_fr_len = FsFr::from_u64(data.len() as u64).inverse();
-            ret[..data.len()]
-                .iter_mut()
-                .for_each(|f| *f = f.mul(&inv_fr_len));
+            ret.iter_mut().for_each(|f| *f = f.mul(&inv_fr_len));
         }
 
         Ok(ret)

--- a/blst-from-scratch/src/zero_poly.rs
+++ b/blst-from-scratch/src/zero_poly.rs
@@ -29,8 +29,6 @@ pub fn pad_poly(mut poly: Vec<FsFr>, new_length: usize) -> Result<Vec<FsFr>, Str
 
 #[allow(clippy::needless_range_loop)]
 impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
-    /// Calculates a polynomial that evaluates to zero for roots of unity at given indices.
-    /// The returned polynomial has a length of idxs.len() + 1.
     fn do_zero_poly_mul_partial(&self, idxs: &[usize], stride: usize) -> Result<FsPoly, String> {
         if idxs.is_empty() {
             return Err(String::from("idx array must not be empty"));
@@ -62,8 +60,6 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
         Ok(FsPoly { coeffs })
     }
 
-    /// Reduce partials using a specified domain size.
-    /// Calculates the product of all polynomials via FFT and then applies an inverse FFT to produce a new Polynomial.
     fn reduce_partials(&self, domain_size: usize, partials: &[FsPoly]) -> Result<FsPoly, String> {
         if !domain_size.is_power_of_two() {
             return Err(String::from("Expected domain size to be a power of 2"));

--- a/blst-from-scratch/src/zero_poly.rs
+++ b/blst-from-scratch/src/zero_poly.rs
@@ -16,7 +16,7 @@ use rayon::prelude::*;
 use smallvec::{smallvec, SmallVec};
 
 // Can be tuned & optimized (must be a power of 2)
-const DEGREE_OF_PARTIAL: usize = 64;
+const DEGREE_OF_PARTIAL: usize = 256;
 // Can be tuned & optimized (but must be a power of 2)
 const REDUCTION_FACTOR: usize = 4;
 

--- a/blst-from-scratch/src/zero_poly.rs
+++ b/blst-from-scratch/src/zero_poly.rs
@@ -28,7 +28,7 @@ pub fn pad_poly(mut poly: Vec<FsFr>, new_length: usize) -> Result<Vec<FsFr>, Str
 }
 
 #[allow(clippy::needless_range_loop)]
-impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
+impl FsFFTSettings {
     fn do_zero_poly_mul_partial(&self, idxs: &[usize], stride: usize) -> Result<FsPoly, String> {
         if idxs.is_empty() {
             return Err(String::from("idx array must not be empty"));
@@ -100,6 +100,16 @@ impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
         };
 
         Ok(ret)
+    }
+}
+
+impl ZeroPoly<FsFr, FsPoly> for FsFFTSettings {
+    fn do_zero_poly_mul_partial(&self, idxs: &[usize], stride: usize) -> Result<FsPoly, String> {
+        self.do_zero_poly_mul_partial(idxs, stride)
+    }
+
+    fn reduce_partials(&self, domain_size: usize, partials: &[FsPoly]) -> Result<FsPoly, String> {
+        self.reduce_partials(domain_size, partials)
     }
 
     fn zero_poly_via_multiplication(

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -108,15 +108,30 @@ pub trait DAS<Coeff: Fr> {
 }
 
 pub trait ZeroPoly<Coeff: Fr, Polynomial: Poly<Coeff>> {
+    /// Calculates the minimal polynomial that evaluates to zero for powers of roots of unity at the
+    /// given indices.
+    /// The returned polynomial has a length of `idxs.len() + 1`.
+    ///
+    /// Uses straightforward long multiplication to calculate the product of `(x - r^i)` where `r`
+    /// is a root of unity and the `i`s are the indices at which it must evaluate to zero.
     fn do_zero_poly_mul_partial(&self, idxs: &[usize], stride: usize)
         -> Result<Polynomial, String>;
 
+    /// Reduce partials using a specified domain size.
+    /// Calculates the product of all polynomials via FFT and then applies an inverse FFT to produce
+    /// a new Polynomial.
     fn reduce_partials(
         &self,
         domain_size: usize,
         partials: &[Polynomial],
     ) -> Result<Polynomial, String>;
 
+    /// Calculate the minimal polynomial that evaluates to zero for powers of roots of unity that
+    /// correspond to missing indices.
+    /// This is done simply by multiplying together `(x - r^i)` for all the `i` that are missing
+    /// indices, using a combination of direct multiplication ([`Self::do_zero_poly_mul_partial()`])
+    /// and iterated multiplication via convolution (#reduce_partials).
+    /// Also calculates the FFT (the "evaluation polynomial").
     fn zero_poly_via_multiplication(
         &self,
         domain_size: usize,

--- a/mcl/kzg/src/zero_poly.rs
+++ b/mcl/kzg/src/zero_poly.rs
@@ -23,8 +23,10 @@ pub fn pad_poly(new_length: usize, poly: &Polynomial) -> Result<Vec<Fr>, String>
 
 impl FFTSettings {
     /// Calculates the minimal polynomial that evaluates to zero for powers of roots of unity at the given indices.
-    /// Uses straightforward long multiplication to calculate the product of `(x - r^i)` where `r` is a root of unity and the
-    /// `i`s are the indices at which it must evaluate to zero. This results in a polynomial of degree @p len_indices.
+    /// The returned polynomial has a length of `idxs.len() + 1`.
+    ///
+    /// Uses straightforward long multiplication to calculate the product of `(x - r^i)` where `r` is a root of unity
+    /// and the `i`s are the indices at which it must evaluate to zero.
     pub fn do_zero_poly_mul_partial(
         &self,
         indices: &[usize],
@@ -51,8 +53,8 @@ impl FFTSettings {
         Ok(poly)
     }
 
-    /// Calculate the product of the input polynomials via convolution.
-    /// Pad the polynomials in @p ps, perform FFTs, point-wise multiply the results together, and apply an inverse FFT to the result
+    /// Reduce partials using a specified domain size.
+    /// Calculates the product of all polynomials via FFT and then applies an inverse FFT to produce a new Polynomial.
     pub fn reduce_partials(
         &self,
         len_out: usize,
@@ -90,9 +92,11 @@ impl FFTSettings {
 
         Ok(ret)
     }
-    /// Calculate the minimal polynomial that evaluates to zero for powers of roots of unity that correspond to missing indices.
-    /// This is done simply by multiplying together `(x - r^i)` for all the `i` that are missing indices, using a combination
-    /// of direct multiplication (#do_zero_poly_mul_partial) and iterated multiplication via convolution (#reduce_partials).
+    /// Calculate the minimal polynomial that evaluates to zero for powers of roots of unity that correspond to missing
+    /// indices.
+    /// This is done simply by multiplying together `(x - r^i)` for all the `i` that are missing indices, using a
+    /// combination of direct multiplication ([`Self::do_zero_poly_mul_partial()`]) and iterated multiplication via
+    /// convolution (#reduce_partials).
     /// Also calculates the FFT (the "evaluation polynomial").
     pub fn zero_poly_via_multiplication(
         &self,

--- a/mcl/kzg/src/zero_poly.rs
+++ b/mcl/kzg/src/zero_poly.rs
@@ -122,7 +122,7 @@ impl FFTSettings {
             return Err(String::from("Length must be a power of 2"));
         }
 
-        let degree_of_partial = 64; // Tunable parameter. Must be a power of two.
+        let degree_of_partial = 256; // Tunable parameter. Must be a power of two.
         let missing_per_partial = degree_of_partial - 1;
         let domain_stride = self.max_width / length;
         let mut partial_count = 1 + (missing_indices.len() - 1) / missing_per_partial;

--- a/zkcrypto/src/zero_poly.rs
+++ b/zkcrypto/src/zero_poly.rs
@@ -114,7 +114,7 @@ impl ZeroPoly<blsScalar, ZPoly> for ZkFFTSettings {
             return Err(String::from("Domain size must be a power of 2"));
         }
 
-        let degree_of_partial = 64;
+        let degree_of_partial = 256;
         let missing_per_partial = degree_of_partial - 1;
         let domain_stride = self.max_width as usize / length;
         let mut partial_count =


### PR DESCRIPTION
I was trying to get substantial improvements given how inefficient it seems (over 50% of cache misses, CPU cores underutilized in parallel mode, etc).

The changes I did are mechanical, they don't change what code does, only (a bit) how. I think there is still improvements to be done in `zero_poly_via_multiplication`, but I don't have enough math background for now, maybe we'll tackle it with @dariolina in the future. I have not checked assembly, but I think Rust is not able to statically verify bounds in all cases and that might result in extra checks still present in the binary that could be eliminated with better structured code or some unsafe operations.

Net result is ~2x performance improvement for recover benchmark with scale 15 in parallel mode. If we can bump `DEGREE_OF_PARTIAL` from current 64 to 256, improvement will be ~2.5x (any concerns with increasing it?).

Not all changes had significant impact, but they all contributed a bit (as far as my noisy CPU allows to measure).