### PR TITLE
Recover poly coefficients

### DIFF
--- a/arkworks/src/recover.rs
+++ b/arkworks/src/recover.rs
@@ -78,7 +78,7 @@ pub fn unscale_poly(p: &mut PolyData) {
     }
 }
 impl PolyRecover<BlstFr, PolyData, FFTSettings> for PolyData {
-    fn recover_poly_from_samples(
+    fn recover_poly_coeffs_from_samples(
         samples: &[Option<BlstFr>],
         fs: &FFTSettings,
     ) -> Result<Self, String> {
@@ -202,7 +202,14 @@ impl PolyRecover<BlstFr, PolyData, FFTSettings> for PolyData {
         unscale_poly(&mut scaled_reconstructed_poly);
 
         // Finally we have D(x) which evaluates to our original data at the powers of roots of unity
-        let reconstructed_poly = scaled_reconstructed_poly; // Renaming
+        Ok(scaled_reconstructed_poly)
+    }
+
+    fn recover_poly_from_samples(
+        samples: &[Option<BlstFr>],
+        fs: &FFTSettings,
+    ) -> Result<Self, String> {
+        let reconstructed_poly = Self::recover_poly_coeffs_from_samples(samples, fs)?;
 
         // The evaluation polynomial for D(x) is the reconstructed data:
         let out = PolyData {

--- a/blst/src/recovery.rs
+++ b/blst/src/recovery.rs
@@ -1,15 +1,17 @@
 extern crate alloc;
 
 use alloc::string::String;
-use alloc::vec;
 use alloc::vec::Vec;
 
-use kzg::{FFTFr, Fr, ZeroPoly};
+use kzg::{FFTFr, Fr, PolyRecover, ZeroPoly};
 
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
 use crate::types::poly::FsPoly;
 use once_cell::sync::OnceCell;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 const SCALE_FACTOR: u64 = 5;
 static INVERSE_FACTORS: OnceCell<Vec<FsFr>> = OnceCell::new();
@@ -56,140 +58,130 @@ pub fn unscale_poly(p: &mut [FsFr], len_p: usize) {
         });
 }
 
-pub fn recover_poly_from_samples(
-    samples: &[FsFr],
-    len_samples: usize,
-    fs: &FsFFTSettings,
-) -> Result<Vec<FsFr>, String> {
-    if !len_samples.is_power_of_two() {
-        return Err(String::from("len_samples must be a power of two"));
-    }
+impl PolyRecover<FsFr, FsPoly, FsFFTSettings> for FsPoly {
+    fn recover_poly_from_samples(
+        samples: &[Option<FsFr>],
+        fs: &FsFFTSettings,
+    ) -> Result<Self, String> {
+        let len_samples = samples.len();
 
-    let mut missing: Vec<usize> = Vec::new();
-    for (i, sample) in samples.iter().enumerate() {
-        if sample.is_null() {
-            missing.push(i);
-        }
-    }
-
-    if missing.len() > len_samples / 2 {
-        return Err(String::from(
-            "Impossible to recover, too many shards are missing",
-        ));
-    }
-
-    // Calculate `Z_r,I`
-    let (zero_eval, mut zero_poly) = fs.zero_poly_via_multiplication(len_samples, &missing)?;
-
-    for i in 0..len_samples {
-        if samples[i].is_null() != zero_eval[i].is_zero() {
+        if !len_samples.is_power_of_two() {
             return Err(String::from(
-                "recovery error: samples should be null when and only when zero_eval is zero",
+                "Samples must have a length that is a power of two",
             ));
         }
-    }
 
-    let mut poly_evaluations_with_zero = FsPoly::default();
+        let mut missing = Vec::with_capacity(len_samples / 2);
 
-    // Construct E * Z_r,I: the loop makes the evaluation polynomial
-    for i in 0..len_samples {
-        if samples[i].is_null() {
-            poly_evaluations_with_zero.coeffs.push(FsFr::zero());
-        } else {
-            poly_evaluations_with_zero
-                .coeffs
-                .push(samples[i].mul(&zero_eval[i]));
+        for (i, sample) in samples.iter().enumerate() {
+            if sample.is_none() {
+                missing.push(i);
+            }
         }
-    }
-    // Now inverse FFT so that poly_with_zero is (E * Z_r,I)(x) = (D * Z_r,I)(x)
-    let mut poly_with_zero = FsPoly {
-        coeffs: fs.fft_fr(&poly_evaluations_with_zero.coeffs, true).unwrap(),
-    };
 
-    // x -> k * x
-    let len_zero_poly = zero_poly.coeffs.len();
-
-    let _zero_poly_scale = (len_zero_poly - 1).next_power_of_two();
-    #[cfg(feature = "parallel")]
-    {
-        if _zero_poly_scale > 1024 {
-            rayon::join(
-                || scale_poly(&mut poly_with_zero.coeffs, len_samples),
-                || scale_poly(&mut zero_poly.coeffs, len_zero_poly),
-            );
-        } else {
-            scale_poly(&mut poly_with_zero.coeffs, len_samples);
-            scale_poly(&mut zero_poly.coeffs, len_zero_poly);
+        if missing.len() > len_samples / 2 {
+            return Err(String::from(
+                "Impossible to recover, too many shards are missing",
+            ));
         }
-    }
 
-    #[cfg(not(feature = "parallel"))]
-    {
-        scale_poly(&mut poly_with_zero.coeffs, len_samples);
+        // Calculate `Z_r,I`
+        let (zero_eval, mut zero_poly) = fs.zero_poly_via_multiplication(len_samples, &missing)?;
+
+        // Construct E * Z_r,I: the loop makes the evaluation polynomial
+        let poly_evaluations_with_zero = samples
+            .iter()
+            .zip(zero_eval)
+            .map(|(maybe_sample, zero_eval)| {
+                debug_assert_eq!(maybe_sample.is_none(), zero_eval.is_zero());
+
+                match maybe_sample {
+                    Some(sample) => sample.mul(&zero_eval),
+                    None => FsFr::zero(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Now inverse FFT so that poly_with_zero is (E * Z_r,I)(x) = (D * Z_r,I)(x)
+        let mut poly_with_zero = fs.fft_fr(&poly_evaluations_with_zero, true).unwrap();
+        drop(poly_evaluations_with_zero);
+
+        // x -> k * x
+        let len_zero_poly = zero_poly.coeffs.len();
+        scale_poly(&mut poly_with_zero, len_samples);
         scale_poly(&mut zero_poly.coeffs, len_zero_poly);
-    }
 
-    // Q1 = (D * Z_r,I)(k * x)
-    let scaled_poly_with_zero = poly_with_zero.coeffs;
+        // Q1 = (D * Z_r,I)(k * x)
+        let scaled_poly_with_zero = poly_with_zero;
 
-    // Q2 = Z_r,I(k * x)
-    let scaled_zero_poly = zero_poly.coeffs;
+        // Q2 = Z_r,I(k * x)
+        let scaled_zero_poly = zero_poly.coeffs;
 
-    #[allow(unused_assignments)]
-    let mut eval_scaled_poly_with_zero = vec![];
-    #[allow(unused_assignments)]
-    let mut eval_scaled_zero_poly = vec![];
+        // Polynomial division by convolution: Q3 = Q1 / Q2
+        #[cfg(feature = "parallel")]
+        let (eval_scaled_poly_with_zero, eval_scaled_zero_poly) = {
+            if len_zero_poly - 1 > 1024 {
+                rayon::join(
+                    || fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
+                    || fs.fft_fr(&scaled_zero_poly, false).unwrap(),
+                )
+            } else {
+                (
+                    fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
+                    fs.fft_fr(&scaled_zero_poly, false).unwrap(),
+                )
+            }
+        };
+        #[cfg(not(feature = "parallel"))]
+        let (eval_scaled_poly_with_zero, eval_scaled_zero_poly) = {
+            (
+                fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
+                fs.fft_fr(&scaled_zero_poly, false).unwrap(),
+            )
+        };
+        drop(scaled_zero_poly);
 
-    // Polynomial division by convolution: Q3 = Q1 / Q2
-    #[cfg(feature = "parallel")]
-    {
-        if _zero_poly_scale > 1024 {
-            rayon::join(
-                || eval_scaled_poly_with_zero = fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
-                || eval_scaled_zero_poly = fs.fft_fr(&scaled_zero_poly, false).unwrap(),
+        let mut eval_scaled_reconstructed_poly = eval_scaled_poly_with_zero;
+        #[cfg(not(feature = "parallel"))]
+        let eval_scaled_reconstructed_poly_iter = eval_scaled_reconstructed_poly.iter_mut();
+        #[cfg(feature = "parallel")]
+        let eval_scaled_reconstructed_poly_iter = eval_scaled_reconstructed_poly.par_iter_mut();
+
+        eval_scaled_reconstructed_poly_iter
+            .zip(eval_scaled_zero_poly)
+            .for_each(
+                |(eval_scaled_reconstructed_poly, eval_scaled_poly_with_zero)| {
+                    *eval_scaled_reconstructed_poly = eval_scaled_reconstructed_poly
+                        .div(&eval_scaled_poly_with_zero)
+                        .unwrap();
+                },
             );
-        } else {
-            eval_scaled_poly_with_zero = fs.fft_fr(&scaled_poly_with_zero, false).unwrap();
-            eval_scaled_zero_poly = fs.fft_fr(&scaled_zero_poly, false).unwrap();
-        }
+
+        // The result of the division is D(k * x):
+        let mut scaled_reconstructed_poly =
+            fs.fft_fr(&eval_scaled_reconstructed_poly, true).unwrap();
+        drop(eval_scaled_reconstructed_poly);
+
+        // k * x -> x
+        unscale_poly(&mut scaled_reconstructed_poly, len_samples);
+
+        // Finally we have D(x) which evaluates to our original data at the powers of roots of unity
+        let reconstructed_poly = scaled_reconstructed_poly;
+
+        // The evaluation polynomial for D(x) is the reconstructed data:
+        let reconstructed_data = fs.fft_fr(&reconstructed_poly, false).unwrap();
+        drop(reconstructed_poly);
+
+        // Check all is well
+        samples
+            .iter()
+            .zip(&reconstructed_data)
+            .for_each(|(sample, reconstructed_data)| {
+                debug_assert!(sample.is_none() || reconstructed_data.equals(&sample.unwrap()));
+            });
+
+        Ok(FsPoly {
+            coeffs: reconstructed_data,
+        })
     }
-    #[cfg(not(feature = "parallel"))]
-    {
-        eval_scaled_poly_with_zero = fs.fft_fr(&scaled_poly_with_zero, false).unwrap();
-        eval_scaled_zero_poly = fs.fft_fr(&scaled_zero_poly, false).unwrap();
-    }
-
-    let mut eval_scaled_reconstructed_poly = FsPoly {
-        coeffs: eval_scaled_poly_with_zero.clone(),
-    };
-    for i in 0..len_samples {
-        eval_scaled_reconstructed_poly.coeffs[i] = eval_scaled_poly_with_zero[i]
-            .div(&eval_scaled_zero_poly[i])
-            .unwrap();
-    }
-
-    // The result of the division is D(k * x):
-    let mut scaled_reconstructed_poly: Vec<FsFr> = fs
-        .fft_fr(&eval_scaled_reconstructed_poly.coeffs, true)
-        .unwrap();
-
-    // k * x -> x
-    unscale_poly(&mut scaled_reconstructed_poly, len_samples);
-
-    // Finally we have D(x) which evaluates to our original data at the powers of roots of unity
-    let reconstructed_poly = scaled_reconstructed_poly;
-
-    // The evaluation polynomial for D(x) is the reconstructed data:
-    let reconstructed_data = fs.fft_fr(&reconstructed_poly, false).unwrap();
-
-    // Check all is well
-    for i in 0..len_samples {
-        if !(samples[i].is_null() || reconstructed_data[i].equals(&samples[i])) {
-            return Err(String::from(
-                "recovery error: samples should be null or equal reconstructed data",
-            ));
-        }
-    }
-
-    Ok(reconstructed_data)
 }

--- a/blst/src/types/poly.rs
+++ b/blst/src/types/poly.rs
@@ -4,16 +4,12 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use kzg::{FFTFr, FFTSettings, FFTSettingsPoly, Fr, Poly, PolyRecover, ZeroPoly};
+use kzg::{FFTFr, FFTSettings, FFTSettingsPoly, Fr, Poly};
 
 use crate::consts::SCALE_FACTOR;
-use crate::recovery::{scale_poly, unscale_poly};
 use crate::types::fft_settings::FsFFTSettings;
 use crate::types::fr::FsFr;
 use crate::utils::{log2_pow2, log2_u64};
-
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct FsPoly {
@@ -406,133 +402,5 @@ impl FsPoly {
         } else {
             self.mul_fft(multiplier, output_len)
         }
-    }
-}
-
-impl PolyRecover<FsFr, FsPoly, FsFFTSettings> for FsPoly {
-    fn recover_poly_from_samples(
-        samples: &[Option<FsFr>],
-        fs: &FsFFTSettings,
-    ) -> Result<Self, String> {
-        let len_samples = samples.len();
-
-        if !len_samples.is_power_of_two() {
-            return Err(String::from(
-                "Samples must have a length that is a power of two",
-            ));
-        }
-
-        let mut missing = Vec::with_capacity(len_samples / 2);
-
-        for (i, sample) in samples.iter().enumerate() {
-            if sample.is_none() {
-                missing.push(i);
-            }
-        }
-
-        if missing.len() > len_samples / 2 {
-            return Err(String::from(
-                "Impossible to recover, too many shards are missing",
-            ));
-        }
-
-        // Calculate `Z_r,I`
-        let (zero_eval, mut zero_poly) = fs.zero_poly_via_multiplication(len_samples, &missing)?;
-
-        // Construct E * Z_r,I: the loop makes the evaluation polynomial
-        let poly_evaluations_with_zero = samples
-            .iter()
-            .zip(zero_eval)
-            .map(|(maybe_sample, zero_eval)| {
-                debug_assert_eq!(maybe_sample.is_none(), zero_eval.is_zero());
-
-                match maybe_sample {
-                    Some(sample) => sample.mul(&zero_eval),
-                    None => FsFr::zero(),
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // Now inverse FFT so that poly_with_zero is (E * Z_r,I)(x) = (D * Z_r,I)(x)
-        let mut poly_with_zero = fs.fft_fr(&poly_evaluations_with_zero, true).unwrap();
-        drop(poly_evaluations_with_zero);
-
-        // x -> k * x
-        let len_zero_poly = zero_poly.coeffs.len();
-        scale_poly(&mut poly_with_zero, len_samples);
-        scale_poly(&mut zero_poly.coeffs, len_zero_poly);
-
-        // Q1 = (D * Z_r,I)(k * x)
-        let scaled_poly_with_zero = poly_with_zero;
-
-        // Q2 = Z_r,I(k * x)
-        let scaled_zero_poly = zero_poly.coeffs;
-
-        // Polynomial division by convolution: Q3 = Q1 / Q2
-        #[cfg(feature = "parallel")]
-        let (eval_scaled_poly_with_zero, eval_scaled_zero_poly) = {
-            if len_zero_poly - 1 > 1024 {
-                rayon::join(
-                    || fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
-                    || fs.fft_fr(&scaled_zero_poly, false).unwrap(),
-                )
-            } else {
-                (
-                    fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
-                    fs.fft_fr(&scaled_zero_poly, false).unwrap(),
-                )
-            }
-        };
-        #[cfg(not(feature = "parallel"))]
-        let (eval_scaled_poly_with_zero, eval_scaled_zero_poly) = {
-            (
-                fs.fft_fr(&scaled_poly_with_zero, false).unwrap(),
-                fs.fft_fr(&scaled_zero_poly, false).unwrap(),
-            )
-        };
-        drop(scaled_zero_poly);
-
-        let mut eval_scaled_reconstructed_poly = eval_scaled_poly_with_zero;
-        #[cfg(not(feature = "parallel"))]
-        let eval_scaled_reconstructed_poly_iter = eval_scaled_reconstructed_poly.iter_mut();
-        #[cfg(feature = "parallel")]
-        let eval_scaled_reconstructed_poly_iter = eval_scaled_reconstructed_poly.par_iter_mut();
-
-        eval_scaled_reconstructed_poly_iter
-            .zip(eval_scaled_zero_poly)
-            .for_each(
-                |(eval_scaled_reconstructed_poly, eval_scaled_poly_with_zero)| {
-                    *eval_scaled_reconstructed_poly = eval_scaled_reconstructed_poly
-                        .div(&eval_scaled_poly_with_zero)
-                        .unwrap();
-                },
-            );
-
-        // The result of the division is D(k * x):
-        let mut scaled_reconstructed_poly =
-            fs.fft_fr(&eval_scaled_reconstructed_poly, true).unwrap();
-        drop(eval_scaled_reconstructed_poly);
-
-        // k * x -> x
-        unscale_poly(&mut scaled_reconstructed_poly, len_samples);
-
-        // Finally we have D(x) which evaluates to our original data at the powers of roots of unity
-        let reconstructed_poly = scaled_reconstructed_poly;
-
-        // The evaluation polynomial for D(x) is the reconstructed data:
-        let reconstructed_data = fs.fft_fr(&reconstructed_poly, false).unwrap();
-        drop(reconstructed_poly);
-
-        // Check all is well
-        samples
-            .iter()
-            .zip(&reconstructed_data)
-            .for_each(|(sample, reconstructed_data)| {
-                debug_assert!(sample.is_none() || reconstructed_data.equals(&sample.unwrap()));
-            });
-
-        Ok(FsPoly {
-            coeffs: reconstructed_data,
-        })
     }
 }

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -199,6 +199,11 @@ pub trait Poly<Coeff: Fr>: Default + Clone {
 }
 
 pub trait PolyRecover<Coeff: Fr, Polynomial: Poly<Coeff>, FSettings: FFTSettings<Coeff>> {
+    fn recover_poly_coeffs_from_samples(
+        samples: &[Option<Coeff>],
+        fs: &FSettings,
+    ) -> Result<Polynomial, String>;
+
     fn recover_poly_from_samples(
         samples: &[Option<Coeff>],
         fs: &FSettings,

--- a/mcl/kzg/src/data_recovery.rs
+++ b/mcl/kzg/src/data_recovery.rs
@@ -76,7 +76,7 @@ impl Polynomial {
         }
     }
 
-    pub fn recover_from_samples(
+    pub fn recover_coeffs_from_samples(
         fft_settings: &FFTSettings,
         samples: &[Option<Fr>],
     ) -> Result<Self, String> {
@@ -185,8 +185,18 @@ impl Polynomial {
         let mut shifted_reconstructed_poly = Polynomial::from_fr(shifted_reconstructed_poly_coeffs);
         shifted_reconstructed_poly.unshift_in_place();
 
+        Ok(shifted_reconstructed_poly)
+    }
+
+    pub fn recover_from_samples(
+        fft_settings: &FFTSettings,
+        samples: &[Option<Fr>],
+    ) -> Result<Self, String> {
         let reconstructed_data = fft_settings
-            .fft(&shifted_reconstructed_poly.coeffs, false)
+            .fft(
+                &Self::recover_coeffs_from_samples(fft_settings, samples)?.coeffs,
+                false,
+            )
             .unwrap();
 
         Ok(Polynomial::from_fr(reconstructed_data))

--- a/mcl/kzg/src/trait_implementations/poly.rs
+++ b/mcl/kzg/src/trait_implementations/poly.rs
@@ -71,6 +71,12 @@ impl FFTSettingsPoly<Fr, Polynomial, FFTSettings> for FFTSettings {
 }
 
 impl PolyRecover<Fr, Polynomial, FFTSettings> for Polynomial {
+    fn recover_poly_coeffs_from_samples(
+        samples: &[Option<Fr>],
+        fs: &FFTSettings,
+    ) -> Result<Self, String> {
+        Polynomial::recover_coeffs_from_samples(fs, samples)
+    }
     fn recover_poly_from_samples(samples: &[Option<Fr>], fs: &FFTSettings) -> Result<Self, String> {
         Polynomial::recover_from_samples(fs, samples)
     }


### PR DESCRIPTION
First commit just moves trait implementation from one file to another, as discussed previously the standalone function is not necessary. Second commit adds new method to all implementations in a straightforward way (except `ckzg` that does not compile anyway).

Resolves #200