### PR TITLE
Fix slow type conversion in C API

### DIFF
--- a/kzg/src/eip_4844.rs
+++ b/kzg/src/eip_4844.rs
@@ -155,3 +155,16 @@ pub fn bytes48_from_hex(hex: &str) -> [u8; BYTES_PER_G1] {
     }
     out
 }
+
+#[macro_export]
+macro_rules! cfg_into_iter {
+    ($e: expr) => {{
+        #[cfg(feature = "parallel")]
+        let result = $e.into_par_iter();
+
+        #[cfg(not(feature = "parallel"))]
+        let result = $e.into_iter();
+
+        result
+    }};
+}


### PR DESCRIPTION
Bindings that used the exported function `verify_blob_kzg_proof_batch` were 2x slower than the native implementation because rust-kzg with blst backend in `FsG1::from_bytes` performs additional checks (according to the spec), such as:

* whether the point is on the curve
* whether the point is on the right subgroup

Here are the local benchmark results for hooking up the blst backend to the Rust binding from c-kzg-4844. I ran it twice, first without my changes and then with my changes:

<details><summary>Details</summary>
<p>

```text
verify_blob_kzg_proof_batch/1
                        time:   [3.2226 ms 3.2301 ms 3.2381 ms]
                        thrpt:  [308.83  elem/s 309.59  elem/s 310.31  elem/s]
                 change:
                        time:   [-0.4537% -0.0829% +0.2789%] (p = 0.66 > 0.05)
                        thrpt:  [-0.2781% +0.0830% +0.4558%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
verify_blob_kzg_proof_batch/2
                        time:   [4.1799 ms 4.1931 ms 4.2063 ms]
                        thrpt:  [475.48  elem/s 476.97  elem/s 478.48  elem/s]
                 change:
                        time:   [-3.1426% -2.7764% -2.4346%] (p = 0.00 < 0.05)
                        thrpt:  [+2.4954% +2.8556% +3.2445%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
verify_blob_kzg_proof_batch/4
                        time:   [4.0871 ms 4.1013 ms 4.1168 ms]
                        thrpt:  [971.62  elem/s 975.30  elem/s 978.68  elem/s]
                 change:
                        time:   [-21.958% -21.543% -21.144%] (p = 0.00 < 0.05)
                        thrpt:  [+26.813% +27.459% +28.136%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
verify_blob_kzg_proof_batch/8
                        time:   [6.5825 ms 6.6023 ms 6.6231 ms]
                        thrpt:  [1.2079 Kelem/s 1.2117 Kelem/s 1.2154 Kelem/s]
                 change:
                        time:   [-26.230% -25.757% -25.314%] (p = 0.00 < 0.05)
                        thrpt:  [+33.894% +34.693% +35.556%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
verify_blob_kzg_proof_batch/16
                        time:   [11.816 ms 11.869 ms 11.928 ms]
                        thrpt:  [1.3414 Kelem/s 1.3480 Kelem/s 1.3541 Kelem/s]
                 change:
                        time:   [-28.352% -27.859% -27.351%] (p = 0.00 < 0.05)
                        thrpt:  [+37.649% +38.618% +39.572%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
verify_blob_kzg_proof_batch/32
                        time:   [21.519 ms 21.585 ms 21.671 ms]
                        thrpt:  [1.4766 Kelem/s 1.4825 Kelem/s 1.4870 Kelem/s]
                 change:
                        time:   [-31.060% -30.749% -30.393%] (p = 0.00 < 0.05)
                        thrpt:  [+43.664% +44.402% +45.054%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
verify_blob_kzg_proof_batch/64
                        time:   [40.782 ms 40.868 ms 40.975 ms]
                        thrpt:  [1.5619 Kelem/s 1.5660 Kelem/s 1.5693 Kelem/s]
                 change:
                        time:   [-34.299% -34.096% -33.879%] (p = 0.00 < 0.05)
                        thrpt:  [+51.238% +51.737% +52.205%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

```

</p>
</details> 