### PR TITLE
Update package names

### DIFF
--- a/.github/workflows/mcl-benchmarks.yml
+++ b/.github/workflows/mcl-benchmarks.yml
@@ -24,27 +24,27 @@ jobs:
         with:
           go-version: ^1.19
 
-      - name: "[mcl10-rust] Build native libs for Linux"
+      - name: "[mcl] Build native libs for Linux"
         if: matrix.os == 'ubuntu-latest'
         run: |
           cd mcl/kzg && bash build.sh
 
-      - name: "[mcl10-rust] Benchmark"
+      - name: "[mcl] Benchmark"
         if: matrix.os == 'ubuntu-latest'
         run: |
           cargo bench --manifest-path mcl/kzg-bench/Cargo.toml
 
-      - name: "[mcl10-rust] Benchmark (parallel)"
+      - name: "[mcl] Benchmark (parallel)"
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo bench --manifest-path mcl/kzg-bench/Cargo.toml --features mcl_rust/parallel
+          cargo bench --manifest-path mcl/kzg-bench/Cargo.toml --features rust-kzg-mcl/parallel
 
-      #- name: "[mcl10-rust] Benchmark (c-kzg-4844)"
+      #- name: "[mcl] Benchmark (c-kzg-4844)"
       #  if: matrix.os == 'ubuntu-latest'
       #  run: |
       #    cd mcl/kzg && bash run-c-kzg-4844-benches.sh
 
-      #- name: "[mcl10-rust] Benchmark (c-kzg-4844 parallel)"
+      #- name: "[mcl] Benchmark (c-kzg-4844 parallel)"
       #  if: matrix.os == 'ubuntu-latest'
       #  run: |
       #    cd mcl/kzg && bash run-c-kzg-4844-benches.sh --parallel

--- a/.github/workflows/mcl-tests.yml
+++ b/.github/workflows/mcl-tests.yml
@@ -34,50 +34,50 @@ jobs:
         with:
           go-version: ^1.19
 
-      - name: "[mcl10-rust] Build native libs for Linux"
+      - name: "[mcl] Build native libs for Linux"
         if: matrix.os == 'ubuntu-latest'
         run: |
           cd mcl/kzg && bash build.sh
 
-      - name: "[mcl10-rust] Tests (minimal preset)"
+      - name: "[mcl] Tests (minimal preset)"
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --package mcl_kzg_bench --lib shared_tests::eip_4844::tests --no-fail-fast --features minimal-spec -- --test-threads 1
+          args: --package rust-kzg-mcl-bench --lib shared_tests::eip_4844::tests --no-fail-fast --features minimal-spec -- --test-threads 1
 
-      - name: "[mcl10-rust] Tests (mainnet preset)"
+      - name: "[mcl] Tests (mainnet preset)"
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: shared_tests --manifest-path mcl/kzg-bench/Cargo.toml --no-fail-fast -- --test-threads 1
 
-      - name: "[mcl10-rust] Tests (mainnet preset, parallel)"
+      - name: "[mcl] Tests (mainnet preset, parallel)"
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: shared_tests --manifest-path mcl/kzg-bench/Cargo.toml --no-fail-fast --features mcl_rust/parallel -- --test-threads 1
+          args: shared_tests --manifest-path mcl/kzg-bench/Cargo.toml --no-fail-fast --features rust-kzg-mcl/parallel -- --test-threads 1
 
-      #- name: "[mcl10-rust] Tests (c-kzg-4844)"
+      #- name: "[mcl] Tests (c-kzg-4844)"
       #  if: matrix.os == 'ubuntu-latest'
       #  run: |
       #    cd mcl/kzg && bash run-c-kzg-4844-tests.sh
 
-      #- name: "[mcl10-rust] Tests (c-kzg-4844 parallel)"
+      #- name: "[mcl] Tests (c-kzg-4844 parallel)"
       #  if: matrix.os == 'ubuntu-latest'
       #  run: |
       #    cd mcl/kzg && bash run-c-kzg-4844-tests.sh --parallel
 
-      - name: "[mcl10-rust] Clippy"
+      - name: "[mcl] Clippy"
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --manifest-path mcl/kzg/Cargo.toml --all-targets --all-features -- -D warnings
 
-      - name: "[mcl10-rust] Formatting"
+      - name: "[mcl] Formatting"
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,13 @@ jobs:
       - name: "[blst] Build Linux"
         run: |
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=blst-portable
-          mv target/x86_64-unknown-linux-gnu/release/libblst_rust.a staging/linux/non-parallel/rust-kzg-blst.a
+          mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/non-parallel/rust_kzg_blst.a
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=blst-force-adx
-          mv target/x86_64-unknown-linux-gnu/release/libblst_rust.a staging/linux/non-parallel-force-adx/rust-kzg-blst.a
+          mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/non-parallel-force-adx/rust_kzg_blst.a
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=parallel,blst-portable
-          mv target/x86_64-unknown-linux-gnu/release/libblst_rust.a staging/linux/parallel/rust-kzg-blst.a
+          mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/parallel/rust_kzg_blst.a
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=parallel,blst-force-adx
-          mv target/x86_64-unknown-linux-gnu/release/libblst_rust.a staging/linux/parallel-force-adx/rust-kzg-blst.a
+          mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/parallel-force-adx/rust_kzg_blst.a
 
       - name: "[blst] Compress Linux artifacts"
         run: |
@@ -54,13 +54,13 @@ jobs:
       - name: "[blst] Build Windows"
         run: |
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=blst-portable
-          mv target/x86_64-pc-windows-gnu/release/libblst_rust.a staging/windows/non-parallel/rust-kzg-blst.a
+          mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/non-parallel/rust_kzg_blst.a
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=blst-force-adx
-          mv target/x86_64-pc-windows-gnu/release/libblst_rust.a staging/windows/non-parallel-force-adx/rust-kzg-blst.a
+          mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/non-parallel-force-adx/rust_kzg_blst.a
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=parallel,blst-portable
-          mv target/x86_64-pc-windows-gnu/release/libblst_rust.a staging/windows/parallel/rust-kzg-blst.a
+          mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/parallel/rust_kzg_blst.a
           cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=parallel,blst-force-adx
-          mv target/x86_64-pc-windows-gnu/release/libblst_rust.a staging/windows/parallel-force-adx/rust-kzg-blst.a
+          mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/parallel-force-adx/rust_kzg_blst.a
 
       - name: "[blst] Compress Windows artifacts"
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -83,7 +83,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -200,27 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arkworks"
-version = "0.1.0"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-poly-commit",
- "ark-std",
- "blst",
- "criterion",
- "hex",
- "kzg",
- "kzg-bench",
- "merkle_light",
- "num_cpus",
- "rand",
- "rayon",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,9 +207,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atomic-polyfill"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+checksum = "c314e70d181aa6053b26e3f7fbf86d1dfff84f816a6175b967666b3506ef7289"
 dependencies = [
  "critical-section",
 ]
@@ -272,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -295,7 +274,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.3.10"
-source = "git+https://github.com/supranational/blst.git#ca03e11a3ff24d818ae390a1e7f435f15bf72aee"
+source = "git+https://github.com/supranational/blst.git#a8cd361c9f671577aeab3f074098443af92a53fc"
 dependencies = [
  "cc",
  "glob",
@@ -304,27 +283,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "blst_rust"
-version = "0.1.0"
-dependencies = [
- "blst",
- "criterion",
- "hex",
- "kzg",
- "kzg-bench",
- "libc",
- "num_cpus",
- "once_cell",
- "rand",
- "rayon",
- "smallvec",
-]
-
-[[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -358,9 +320,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -369,15 +331,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -385,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -417,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -468,9 +430,9 @@ checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -478,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -489,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -502,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -533,7 +495,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -547,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -592,9 +554,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -602,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -690,14 +652,14 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -714,15 +676,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -756,45 +718,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "mcl_kzg_bench"
-version = "0.1.0"
-dependencies = [
- "blst",
- "criterion",
- "kzg",
- "kzg-bench",
- "mcl_rust",
- "rand",
-]
-
-[[package]]
-name = "mcl_rust"
-version = "0.0.1"
-dependencies = [
- "blst",
- "cc",
- "hex",
- "kzg",
- "libc",
- "num_cpus",
- "once_cell",
- "primitive-types",
- "rayon",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "memchr"
@@ -804,9 +736,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -859,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 dependencies = [
  "atomic-polyfill",
  "critical-section",
@@ -875,9 +807,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "pairing"
@@ -890,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
+checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -911,20 +843,20 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -993,18 +925,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1047,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -1057,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1069,18 +1001,103 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "rust-kzg-arkworks"
+version = "0.1.0"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-poly-commit",
+ "ark-std",
+ "blst",
+ "criterion",
+ "hex",
+ "kzg",
+ "kzg-bench",
+ "merkle_light",
+ "num_cpus",
+ "rand",
+ "rayon",
+]
+
+[[package]]
+name = "rust-kzg-blst"
+version = "0.1.0"
+dependencies = [
+ "blst",
+ "criterion",
+ "hex",
+ "kzg",
+ "kzg-bench",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "rand",
+ "rayon",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-kzg-mcl"
+version = "0.0.1"
+dependencies = [
+ "blst",
+ "cc",
+ "hex",
+ "kzg",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "primitive-types",
+ "rayon",
+]
+
+[[package]]
+name = "rust-kzg-mcl-bench"
+version = "0.1.0"
+dependencies = [
+ "blst",
+ "criterion",
+ "kzg",
+ "kzg-bench",
+ "rand",
+ "rust-kzg-mcl",
+]
+
+[[package]]
+name = "rust-kzg-zkcrypto"
+version = "0.1.0"
+dependencies = [
+ "bls12_381",
+ "blst",
+ "criterion",
+ "ff",
+ "hex",
+ "kzg",
+ "kzg-bench",
+ "num-bigint",
+ "num_cpus",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "subtle",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -1099,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -1138,29 +1155,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1188,7 +1205,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1221,15 +1238,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "syn"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1246,22 +1262,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1285,15 +1301,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1314,20 +1330,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1368,15 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1398,12 +1408,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -1415,9 +1424,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1425,24 +1434,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1450,28 +1459,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1510,9 +1519,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.3.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
@@ -1528,41 +1537,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zkcrypto"
-version = "0.1.0"
-dependencies = [
- "bls12_381",
- "blst",
- "criterion",
- "ff",
- "hex",
- "kzg",
- "kzg-bench",
- "num-bigint",
- "num_cpus",
- "pairing",
- "rand",
- "rand_core",
- "rayon",
- "subtle",
+ "syn 2.0.18",
 ]

--- a/arkworks/Cargo.toml
+++ b/arkworks/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "arkworks"
+name = "rust-kzg-arkworks"
 version = "0.1.0"
 edition = "2021"
 

--- a/arkworks/benches/das.rs
+++ b/arkworks/benches/das.rs
@@ -1,7 +1,7 @@
-use arkworks::kzg_proofs::FFTSettings;
-use arkworks::kzg_types::FsFr;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::das::bench_das_extension;
+use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+use rust_kzg_arkworks::kzg_types::FsFr;
 
 fn bench_das_extension_(c: &mut Criterion) {
     bench_das_extension::<FsFr, FFTSettings>(c);

--- a/arkworks/benches/eip_4844.rs
+++ b/arkworks/benches/eip_4844.rs
@@ -1,12 +1,12 @@
-use arkworks::eip_4844::{
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::eip_4844::bench_eip_4844;
+use rust_kzg_arkworks::eip_4844::{
     blob_to_kzg_commitment, bytes_to_blob, compute_blob_kzg_proof, compute_kzg_proof,
     load_trusted_setup, verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
 };
-use arkworks::kzg_proofs::{FFTSettings, KZGSettings};
-use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
-use arkworks::utils::PolyData;
-use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::eip_4844::bench_eip_4844;
+use rust_kzg_arkworks::kzg_proofs::{FFTSettings, KZGSettings};
+use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
+use rust_kzg_arkworks::utils::PolyData;
 
 fn bench_eip_4844_(c: &mut Criterion) {
     bench_eip_4844::<FsFr, ArkG1, ArkG2, PolyData, FFTSettings, KZGSettings>(

--- a/arkworks/benches/fft.rs
+++ b/arkworks/benches/fft.rs
@@ -1,7 +1,7 @@
-use arkworks::kzg_proofs::FFTSettings;
-use arkworks::kzg_types::{ArkG1, FsFr};
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fft::{bench_fft_fr, bench_fft_g1};
+use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+use rust_kzg_arkworks::kzg_types::{ArkG1, FsFr};
 
 fn bench_fft_fr_(c: &mut Criterion) {
     bench_fft_fr::<FsFr, FFTSettings>(c);

--- a/arkworks/benches/fk_20.rs
+++ b/arkworks/benches/fk_20.rs
@@ -1,9 +1,9 @@
-use arkworks::fk20_proofs::{KzgFK20MultiSettings, KzgFK20SingleSettings};
-use arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
-use arkworks::utils::PolyData;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fk20::{bench_fk_multi_da, bench_fk_single_da};
+use rust_kzg_arkworks::fk20_proofs::{KzgFK20MultiSettings, KzgFK20SingleSettings};
+use rust_kzg_arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
+use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
+use rust_kzg_arkworks::utils::PolyData;
 
 fn bench_fk_single_da_(c: &mut Criterion) {
     bench_fk_single_da::<

--- a/arkworks/benches/kzg.rs
+++ b/arkworks/benches/kzg.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::kzg::{bench_commit_to_poly, bench_compute_proof_single};
 
-use arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
-use arkworks::utils::PolyData;
+use rust_kzg_arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
+use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
+use rust_kzg_arkworks::utils::PolyData;
 
 fn bench_commit_to_poly_(c: &mut Criterion) {
     bench_commit_to_poly::<FsFr, ArkG1, ArkG2, PolyData, FFTSettings, KZGSettings>(

--- a/arkworks/benches/lincomb.rs
+++ b/arkworks/benches/lincomb.rs
@@ -1,7 +1,7 @@
-use arkworks::fft_g1::g1_linear_combination;
-use arkworks::kzg_types::{ArkG1, FsFr};
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::lincomb::bench_g1_lincomb;
+use rust_kzg_arkworks::fft_g1::g1_linear_combination;
+use rust_kzg_arkworks::kzg_types::{ArkG1, FsFr};
 
 fn bench_g1_lincomb_(c: &mut Criterion) {
     bench_g1_lincomb::<FsFr, ArkG1>(c, &g1_linear_combination);

--- a/arkworks/benches/poly.rs
+++ b/arkworks/benches/poly.rs
@@ -1,7 +1,7 @@
-use arkworks::kzg_types::FsFr;
-use arkworks::utils::PolyData;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::poly::bench_new_poly_div;
+use rust_kzg_arkworks::kzg_types::FsFr;
+use rust_kzg_arkworks::utils::PolyData;
 
 fn bench_new_poly_div_(c: &mut Criterion) {
     bench_new_poly_div::<FsFr, PolyData>(c);

--- a/arkworks/benches/recover.rs
+++ b/arkworks/benches/recover.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::recover::bench_recover;
 
-use arkworks::kzg_proofs::FFTSettings;
-use arkworks::kzg_types::FsFr;
-use arkworks::utils::PolyData;
+use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+use rust_kzg_arkworks::kzg_types::FsFr;
+use rust_kzg_arkworks::utils::PolyData;
 
 fn bench_recover_(c: &mut Criterion) {
     bench_recover::<FsFr, FFTSettings, PolyData, PolyData>(c);

--- a/arkworks/benches/zero_poly.rs
+++ b/arkworks/benches/zero_poly.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::zero_poly::bench_zero_poly;
 
-use arkworks::kzg_proofs::FFTSettings;
-use arkworks::kzg_types::FsFr;
-use arkworks::utils::PolyData;
+use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+use rust_kzg_arkworks::kzg_types::FsFr;
+use rust_kzg_arkworks::utils::PolyData;
 
 fn bench_zero_poly_(c: &mut Criterion) {
     bench_zero_poly::<FsFr, FFTSettings, PolyData>(c);

--- a/arkworks/tests/bls12_381.rs
+++ b/arkworks/tests/bls12_381.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::fft_g1::{g1_linear_combination, log_2_byte};
-    use arkworks::kzg_proofs::pairings_verify;
-    use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
     use kzg_bench::tests::bls12_381::*;
+    use rust_kzg_arkworks::fft_g1::{g1_linear_combination, log_2_byte};
+    use rust_kzg_arkworks::kzg_proofs::pairings_verify;
+    use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
 
     #[test]
     pub fn log_2_byte_works_() {

--- a/arkworks/tests/consts.rs
+++ b/arkworks/tests/consts.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::fft::SCALE2_ROOT_OF_UNITY;
-    use arkworks::kzg_proofs::expand_root_of_unity;
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::FsFr;
     use kzg_bench::tests::consts::{
         expand_roots_is_plausible, new_fft_settings_is_plausible, roots_of_unity_are_plausible,
         roots_of_unity_is_the_expected_size, roots_of_unity_out_of_bounds_fails,
     };
+    use rust_kzg_arkworks::fft::SCALE2_ROOT_OF_UNITY;
+    use rust_kzg_arkworks::kzg_proofs::expand_root_of_unity;
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::FsFr;
 
     #[test]
     fn roots_of_unity_out_of_bounds_fails_() {

--- a/arkworks/tests/das.rs
+++ b/arkworks/tests/das.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::FsFr;
     use kzg_bench::tests::das::{das_extension_test_known, das_extension_test_random};
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::FsFr;
 
     #[test]
     fn das_extension_test_known_() {

--- a/arkworks/tests/eip_4844.rs
+++ b/arkworks/tests/eip_4844.rs
@@ -1,13 +1,5 @@
 #[cfg(test)]
 pub mod tests {
-    use arkworks::eip_4844::{
-        blob_to_kzg_commitment, blob_to_polynomial, bytes_to_blob, compute_blob_kzg_proof,
-        compute_kzg_proof, compute_powers, evaluate_polynomial_in_evaluation_form,
-        load_trusted_setup, verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
-    };
-    use arkworks::kzg_proofs::{FFTSettings, KZGSettings};
-    use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
-    use arkworks::utils::PolyData;
     #[cfg(not(feature = "minimal-spec"))]
     use kzg_bench::tests::eip_4844::compute_and_verify_kzg_proof_within_domain_test;
     use kzg_bench::tests::eip_4844::{
@@ -18,6 +10,14 @@ pub mod tests {
         compute_and_verify_kzg_proof_round_trip_test, compute_kzg_proof_test, compute_powers_test,
         verify_kzg_proof_batch_fails_with_incorrect_proof_test, verify_kzg_proof_batch_test,
     };
+    use rust_kzg_arkworks::eip_4844::{
+        blob_to_kzg_commitment, blob_to_polynomial, bytes_to_blob, compute_blob_kzg_proof,
+        compute_kzg_proof, compute_powers, evaluate_polynomial_in_evaluation_form,
+        load_trusted_setup, verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
+    };
+    use rust_kzg_arkworks::kzg_proofs::{FFTSettings, KZGSettings};
+    use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
+    use rust_kzg_arkworks::utils::PolyData;
 
     #[test]
     pub fn bytes_to_bls_field_test_() {

--- a/arkworks/tests/fft_fr.rs
+++ b/arkworks/tests/fft_fr.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::fft::{fft_fr_fast, fft_fr_slow};
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::FsFr;
     use kzg_bench::tests::fft_fr::{compare_sft_fft, inverse_fft, roundtrip_fft, stride_fft};
+    use rust_kzg_arkworks::fft::{fft_fr_fast, fft_fr_slow};
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::FsFr;
 
     #[test]
     fn compare_sft_fft_() {

--- a/arkworks/tests/fft_g1.rs
+++ b/arkworks/tests/fft_g1.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::fft_g1::{fft_g1_fast, fft_g1_slow, make_data};
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::{ArkG1, FsFr};
     use kzg_bench::tests::fft_g1::{compare_sft_fft, roundtrip_fft, stride_fft};
+    use rust_kzg_arkworks::fft_g1::{fft_g1_fast, fft_g1_slow, make_data};
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::{ArkG1, FsFr};
 
     #[test]
     fn roundtrip_fft_() {

--- a/arkworks/tests/fk20_proofs.rs
+++ b/arkworks/tests/fk20_proofs.rs
@@ -2,11 +2,11 @@
 mod tests {
     use kzg_bench::tests::fk20_proofs::*;
 
-    use arkworks::fk20_proofs::{KzgFK20MultiSettings, KzgFK20SingleSettings};
-    use arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-    use arkworks::kzg_types::FsFr as BlstFr;
-    use arkworks::kzg_types::{ArkG1, ArkG2};
-    use arkworks::utils::PolyData;
+    use rust_kzg_arkworks::fk20_proofs::{KzgFK20MultiSettings, KzgFK20SingleSettings};
+    use rust_kzg_arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
+    use rust_kzg_arkworks::kzg_types::FsFr as BlstFr;
+    use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2};
+    use rust_kzg_arkworks::utils::PolyData;
 
     #[test]
     fn test_fk_single() {

--- a/arkworks/tests/kzg_proofs.rs
+++ b/arkworks/tests/kzg_proofs.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-    use arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
-    use arkworks::utils::PolyData;
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly, proof_multi, proof_single,
     };
+    use rust_kzg_arkworks::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
+    use rust_kzg_arkworks::kzg_types::{ArkG1, ArkG2, FsFr};
+    use rust_kzg_arkworks::utils::PolyData;
 
     #[test]
     fn proof_single_() {

--- a/arkworks/tests/poly.rs
+++ b/arkworks/tests/poly.rs
@@ -1,14 +1,14 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::FsFr;
-    use arkworks::utils::PolyData;
     use kzg_bench::tests::poly::{
         create_poly_of_length_ten, poly_div_by_zero, poly_div_fast_test, poly_div_long_test,
         poly_div_random, poly_eval_0_check, poly_eval_check, poly_eval_nil_check,
         poly_inverse_simple_0, poly_inverse_simple_1, poly_mul_direct_test, poly_mul_fft_test,
         poly_mul_random, poly_test_div,
     };
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::FsFr;
+    use rust_kzg_arkworks::utils::PolyData;
 
     #[test]
     fn create_poly_of_length_ten_() {

--- a/arkworks/tests/recover.rs
+++ b/arkworks/tests/recover.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod recover_tests {
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::FsFr as Fr;
-    use arkworks::utils::PolyData;
     use kzg_bench::tests::recover::*;
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::FsFr as Fr;
+    use rust_kzg_arkworks::utils::PolyData;
 
     #[test]
     fn recover_simple_() {

--- a/arkworks/tests/zero_poly.rs
+++ b/arkworks/tests/zero_poly.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use arkworks::kzg_proofs::FFTSettings;
-    use arkworks::kzg_types::FsFr;
-    use arkworks::utils::PolyData;
     use kzg_bench::tests::zero_poly::{
         check_test_data, reduce_partials_random, test_reduce_partials, zero_poly_252,
         zero_poly_all_but_one, zero_poly_known, zero_poly_random,
     };
+    use rust_kzg_arkworks::kzg_proofs::FFTSettings;
+    use rust_kzg_arkworks::kzg_types::FsFr;
+    use rust_kzg_arkworks::utils::PolyData;
 
     #[test]
     fn test_reduce_partials_() {

--- a/blst/Cargo.toml
+++ b/blst/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "blst_rust"
+name = "rust-kzg-blst"
 version = "0.1.0"
 edition = "2021"
 

--- a/blst/benches/das.rs
+++ b/blst/benches/das.rs
@@ -1,7 +1,7 @@
-use blst_rust::types::fft_settings::FsFFTSettings;
-use blst_rust::types::fr::FsFr;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::das::bench_das_extension;
+use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+use rust_kzg_blst::types::fr::FsFr;
 
 fn bench_das_extension_(c: &mut Criterion) {
     bench_das_extension::<FsFr, FsFFTSettings>(c)

--- a/blst/benches/eip_4844.rs
+++ b/blst/benches/eip_4844.rs
@@ -1,16 +1,16 @@
-use blst_rust::eip_4844::{
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::eip_4844::bench_eip_4844;
+use rust_kzg_blst::eip_4844::{
     bytes_to_blob, compute_blob_kzg_proof_rust, compute_kzg_proof_rust,
     verify_blob_kzg_proof_batch_rust, verify_blob_kzg_proof_rust, verify_kzg_proof_rust,
 };
-use blst_rust::{
+use rust_kzg_blst::{
     eip_4844::{blob_to_kzg_commitment_rust, load_trusted_setup_filename_rust},
     types::{
         fft_settings::FsFFTSettings, fr::FsFr, g1::FsG1, g2::FsG2, kzg_settings::FsKZGSettings,
         poly::FsPoly,
     },
 };
-use criterion::{criterion_group, criterion_main, Criterion};
-use kzg_bench::benches::eip_4844::bench_eip_4844;
 
 fn bench_eip_4844_(c: &mut Criterion) {
     bench_eip_4844::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(

--- a/blst/benches/fft.rs
+++ b/blst/benches/fft.rs
@@ -1,8 +1,8 @@
-use blst_rust::types::fft_settings::FsFFTSettings;
-use blst_rust::types::fr::FsFr;
-use blst_rust::types::g1::FsG1;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fft::{bench_fft_fr, bench_fft_g1};
+use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+use rust_kzg_blst::types::fr::FsFr;
+use rust_kzg_blst::types::g1::FsG1;
 
 fn bench_fft_fr_(c: &mut Criterion) {
     bench_fft_fr::<FsFr, FsFFTSettings>(c);

--- a/blst/benches/fk_20.rs
+++ b/blst/benches/fk_20.rs
@@ -1,15 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fk20::{bench_fk_multi_da, bench_fk_single_da};
 
-use blst_rust::types::fft_settings::FsFFTSettings;
-use blst_rust::types::fk20_multi_settings::FsFK20MultiSettings;
-use blst_rust::types::fk20_single_settings::FsFK20SingleSettings;
-use blst_rust::types::fr::FsFr;
-use blst_rust::types::g1::FsG1;
-use blst_rust::types::g2::FsG2;
-use blst_rust::types::kzg_settings::FsKZGSettings;
-use blst_rust::types::poly::FsPoly;
-use blst_rust::utils::generate_trusted_setup;
+use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+use rust_kzg_blst::types::fk20_multi_settings::FsFK20MultiSettings;
+use rust_kzg_blst::types::fk20_single_settings::FsFK20SingleSettings;
+use rust_kzg_blst::types::fr::FsFr;
+use rust_kzg_blst::types::g1::FsG1;
+use rust_kzg_blst::types::g2::FsG2;
+use rust_kzg_blst::types::kzg_settings::FsKZGSettings;
+use rust_kzg_blst::types::poly::FsPoly;
+use rust_kzg_blst::utils::generate_trusted_setup;
 
 fn bench_fk_single_da_(c: &mut Criterion) {
     bench_fk_single_da::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings, FsFK20SingleSettings>(

--- a/blst/benches/kzg.rs
+++ b/blst/benches/kzg.rs
@@ -1,12 +1,12 @@
-use blst_rust::types::fft_settings::FsFFTSettings;
-use blst_rust::types::fr::FsFr;
-use blst_rust::types::g1::FsG1;
-use blst_rust::types::g2::FsG2;
-use blst_rust::types::kzg_settings::FsKZGSettings;
-use blst_rust::types::poly::FsPoly;
-use blst_rust::utils::generate_trusted_setup;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::kzg::{bench_commit_to_poly, bench_compute_proof_single};
+use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+use rust_kzg_blst::types::fr::FsFr;
+use rust_kzg_blst::types::g1::FsG1;
+use rust_kzg_blst::types::g2::FsG2;
+use rust_kzg_blst::types::kzg_settings::FsKZGSettings;
+use rust_kzg_blst::types::poly::FsPoly;
+use rust_kzg_blst::utils::generate_trusted_setup;
 
 fn bench_commit_to_poly_(c: &mut Criterion) {
     bench_commit_to_poly::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(

--- a/blst/benches/lincomb.rs
+++ b/blst/benches/lincomb.rs
@@ -1,8 +1,8 @@
-use blst_rust::kzg_proofs::g1_linear_combination;
-use blst_rust::types::fr::FsFr;
-use blst_rust::types::g1::FsG1;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::lincomb::bench_g1_lincomb;
+use rust_kzg_blst::kzg_proofs::g1_linear_combination;
+use rust_kzg_blst::types::fr::FsFr;
+use rust_kzg_blst::types::g1::FsG1;
 
 fn bench_g1_lincomb_(c: &mut Criterion) {
     bench_g1_lincomb::<FsFr, FsG1>(c, &g1_linear_combination);

--- a/blst/benches/poly.rs
+++ b/blst/benches/poly.rs
@@ -1,7 +1,7 @@
-use blst_rust::types::fr::FsFr;
-use blst_rust::types::poly::FsPoly;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::poly::bench_new_poly_div;
+use rust_kzg_blst::types::fr::FsFr;
+use rust_kzg_blst::types::poly::FsPoly;
 
 fn bench_new_poly_div_(c: &mut Criterion) {
     bench_new_poly_div::<FsFr, FsPoly>(c);

--- a/blst/benches/recover.rs
+++ b/blst/benches/recover.rs
@@ -1,6 +1,6 @@
-use blst_rust::types::{fft_settings::FsFFTSettings, fr::FsFr, poly::FsPoly};
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::recover::bench_recover;
+use rust_kzg_blst::types::{fft_settings::FsFFTSettings, fr::FsFr, poly::FsPoly};
 
 pub fn bench_recover_(c: &mut Criterion) {
     bench_recover::<FsFr, FsFFTSettings, FsPoly, FsPoly>(c)

--- a/blst/benches/zero_poly.rs
+++ b/blst/benches/zero_poly.rs
@@ -1,6 +1,6 @@
-use blst_rust::types::{fft_settings::FsFFTSettings, fr::FsFr, poly::FsPoly};
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::zero_poly::bench_zero_poly;
+use rust_kzg_blst::types::{fft_settings::FsFFTSettings, fr::FsFr, poly::FsPoly};
 
 fn bench_zero_poly_(c: &mut Criterion) {
     bench_zero_poly::<FsFr, FsFFTSettings, FsPoly>(c);

--- a/blst/csharp.patch
+++ b/blst/csharp.patch
@@ -16,7 +16,7 @@ index d5fa3dc..0a77983 100644
  FIELD_ELEMENTS_PER_BLOB ?= 4096
  INCLUDE_DIRS = ../../src ../../blst/bindings
 -TARGETS = ckzg.c ../../src/c_kzg_4844.c ../../blst/$(BLST_OBJ)
-+TARGETS = ckzg.c ../../../../target/release/libblst_rust.a
++TARGETS = ckzg.c ../../../../target/release/rust_kzg_blst.a
  
  CFLAGS += -O2 -Wall -Wextra -shared
  CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)

--- a/blst/go.patch
+++ b/blst/go.patch
@@ -24,7 +24,7 @@ index aa7f141..7f0f01e 100644
 +// #endif
 +// #include <stdlib.h>
 +// #include "c_kzg_4844.h"
-+// #cgo LDFLAGS: -L${SRCDIR}/../../../../target/release -lblst_rust -lm
++// #cgo LDFLAGS: -L${SRCDIR}/../../../../target/release -l:rust_kzg_blst.a -lm
  import "C"
  
  import (

--- a/blst/java.patch
+++ b/blst/java.patch
@@ -15,7 +15,7 @@ index 4eb21ce..184e501 100644
  INCLUDE_DIRS = ../../src ../../blst/bindings
 
 -TARGETS=c_kzg_4844_jni.c ../../src/c_kzg_4844.c ../../lib/libblst.a
-+TARGETS=c_kzg_4844_jni.c ../../../../target/release/libblst_rust.a
++TARGETS=c_kzg_4844_jni.c ../../../../target/release/rust_kzg_blst.a
 
  CC_FLAGS=
  OPTIMIZATION_LEVEL=-O2

--- a/blst/nodejs.patch
+++ b/blst/nodejs.patch
@@ -1,12 +1,13 @@
-From a88f94c415c9ccc82437b189691e65db3fbd2639 Mon Sep 17 00:00:00 2001
+From 344b90e309d605d454cbb962da0531bcb062b11a Mon Sep 17 00:00:00 2001
 From: belijzajac <tautvydas749@gmail.com>
-Date: Tue, 11 Apr 2023 17:42:08 +0300
+Date: Sat, 17 Jun 2023 19:16:04 +0300
 Subject: [PATCH] Update linking
 
 ---
- bindings/node.js/Makefile    | 1 -
- bindings/node.js/binding.gyp | 6 ++++--
- 2 files changed, 4 insertions(+), 3 deletions(-)
+ bindings/node.js/Makefile    |  1 -
+ bindings/node.js/binding.gyp | 37 +++++-------------------------------
+ bindings/node.js/src/kzg.cxx |  4 ++++
+ 3 files changed, 9 insertions(+), 33 deletions(-)
 
 diff --git a/bindings/node.js/Makefile b/bindings/node.js/Makefile
 index fdf1618..34e54df 100644
@@ -21,28 +22,71 @@ index fdf1618..34e54df 100644
  	@# Build the bindings
  	@$(YARN) node-gyp --loglevel=warn configure
 diff --git a/bindings/node.js/binding.gyp b/bindings/node.js/binding.gyp
-index 69be3ef..8213dd7 100644
+index 69be3ef..349ac0b 100644
 --- a/bindings/node.js/binding.gyp
 +++ b/bindings/node.js/binding.gyp
-@@ -4,14 +4,16 @@
+@@ -3,44 +3,17 @@
+     {
        "target_name": "kzg",
        "sources": [
-         "src/kzg.cxx",
+-        "src/kzg.cxx",
 -        "deps/blst/src/server.c",
 -        "deps/c-kzg/c_kzg_4844.c"
-+        "deps/blst/src/server.c"
++        "src/kzg.cxx"
        ],
        "include_dirs": [
          "<(module_root_dir)/deps/blst/bindings",
          "<(module_root_dir)/deps/c-kzg",
          "<!@(node -p \"require('node-addon-api').include\")"
        ],
+-      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
+-      "conditions": [
+-        ["OS!='win'", {
+-          "sources": ["deps/blst/build/assembly.S"],
+-          "defines": ["FIELD_ELEMENTS_PER_BLOB=<!(echo ${FIELD_ELEMENTS_PER_BLOB:-4096})"],
+-          "cflags_cc": [
+-            "-std=c++17",
+-            "-fPIC"
+-          ]
+-        }],
+-        ["OS=='win'", {
+-          "sources": ["deps/blst/build/win64/*-x86_64.asm"],
+-          "defines": [
+-            "_CRT_SECURE_NO_WARNINGS",
+-            "FIELD_ELEMENTS_PER_BLOB=<!(powershell -Command \"if ($env:FIELD_ELEMENTS_PER_BLOB) { $env:FIELD_ELEMENTS_PER_BLOB } else { 4096 }\")"
+-          ],
+-          "msbuild_settings": {
+-            "ClCompile": {
+-              "AdditionalOptions": ["/std:c++17"]
+-            }
+-          }
+-        }],
+-        ["OS=='mac'", {
+-          "xcode_settings": {
+-            "CLANG_CXX_LIBRARY": "libc++",
+-            "MACOSX_DEPLOYMENT_TARGET": "13.0"
+-          }
+-        }]
+-      ]
 +      "libraries": [
-+        "<(module_root_dir)/../../../../target/release/libblst_rust.a"
++        "<(module_root_dir)/../../../../target/release/rust_kzg_blst.a"
 +      ],
-       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
-       "conditions": [
-         ["OS!='win'", {
++      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]
+     }
+   ]
+ }
+diff --git a/bindings/node.js/src/kzg.cxx b/bindings/node.js/src/kzg.cxx
+index 871aa90..f89b1e3 100644
+--- a/bindings/node.js/src/kzg.cxx
++++ b/bindings/node.js/src/kzg.cxx
+@@ -1,3 +1,7 @@
++#ifndef FIELD_ELEMENTS_PER_BLOB
++#define FIELD_ELEMENTS_PER_BLOB 4096
++#endif
++
+ #include "blst.h"
+ #include "c_kzg_4844.h"
+ #include <iostream>
 -- 
-2.40.0
+2.40.1
 

--- a/blst/python.patch
+++ b/blst/python.patch
@@ -40,7 +40,7 @@ index bf969cb..9179129 100644
 -                library_dirs=["../../lib"],
 -                libraries=["blst"])])
 +                library_dirs=["../../lib", "../../../../target/release"],
-+                libraries=["blst_rust"])])
++                libraries=[":rust_kzg_blst.a"])])
  
  if __name__ == "__main__":
      main()

--- a/blst/run-c-kzg-4844-benches.sh
+++ b/blst/run-c-kzg-4844-benches.sh
@@ -28,7 +28,7 @@ done
 
 ###################### building static libs ######################
 
-print_msg "Compiling libblst_rust"
+print_msg "Compiling rust-kzg-blst"
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
   cargo rustc --release --crate-type=staticlib --features=parallel
@@ -36,6 +36,8 @@ else
   print_msg "Using non-parallel version"
   cargo rustc --release --crate-type=staticlib
 fi
+
+mv ../target/release/librust_kzg_blst.a ../target/release/rust_kzg_blst.a
 
 ###################### cloning c-kzg-4844 ######################
 

--- a/blst/run-c-kzg-4844-tests.sh
+++ b/blst/run-c-kzg-4844-tests.sh
@@ -28,7 +28,7 @@ done
 
 ###################### building static libs ######################
 
-print_msg "Compiling libblst_rust"
+print_msg "Compiling rust-kzg-blst"
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
   cargo rustc --release --crate-type=staticlib --features=parallel
@@ -36,6 +36,8 @@ else
   print_msg "Using non-parallel version"
   cargo rustc --release --crate-type=staticlib
 fi
+
+mv ../target/release/librust_kzg_blst.a ../target/release/rust_kzg_blst.a
 
 ###################### cloning c-kzg-4844 ######################
 

--- a/blst/rust.patch
+++ b/blst/rust.patch
@@ -73,7 +73,7 @@ index d2dba36..ac4153f 100644
      // Finally, tell cargo this provides ckzg
 -    println!("cargo:rustc-link-lib=ckzg");
 +    println!("cargo:rustc-link-search={}", rust_kzg_target_dir.display());
-+    println!("cargo:rustc-link-lib=blst_rust");
++    println!("cargo:rustc-link-arg=-l:rust_kzg_blst.a");
  }
  
  fn make_bindings<P>(

--- a/blst/tests/bls12_381.rs
+++ b/blst/tests/bls12_381.rs
@@ -8,11 +8,11 @@ mod tests {
         p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
     };
 
-    use blst_rust::kzg_proofs::{g1_linear_combination, pairings_verify};
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::g1::FsG1;
-    use blst_rust::types::g2::FsG2;
-    use blst_rust::utils::log_2_byte;
+    use rust_kzg_blst::kzg_proofs::{g1_linear_combination, pairings_verify};
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::g1::FsG1;
+    use rust_kzg_blst::types::g2::FsG2;
+    use rust_kzg_blst::utils::log_2_byte;
 
     #[test]
     fn log_2_byte_works_() {

--- a/blst/tests/consts.rs
+++ b/blst/tests/consts.rs
@@ -3,13 +3,13 @@
 
 #[cfg(test)]
 mod tests {
-    use blst_rust::consts::SCALE2_ROOT_OF_UNITY;
-    use blst_rust::types::fft_settings::{expand_root_of_unity, FsFFTSettings};
-    use blst_rust::types::fr::FsFr;
     use kzg_bench::tests::consts::{
         expand_roots_is_plausible, new_fft_settings_is_plausible, roots_of_unity_are_plausible,
         roots_of_unity_is_the_expected_size, roots_of_unity_out_of_bounds_fails,
     };
+    use rust_kzg_blst::consts::SCALE2_ROOT_OF_UNITY;
+    use rust_kzg_blst::types::fft_settings::{expand_root_of_unity, FsFFTSettings};
+    use rust_kzg_blst::types::fr::FsFr;
 
     // Shared tests
     #[test]

--- a/blst/tests/das.rs
+++ b/blst/tests/das.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
     use kzg_bench::tests::das::{das_extension_test_known, das_extension_test_random};
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
 
     #[test]
     fn das_extension_test_known_() {

--- a/blst/tests/eip_4844.rs
+++ b/blst/tests/eip_4844.rs
@@ -1,15 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use blst_rust::eip_4844::{
-        blob_to_kzg_commitment_rust, blob_to_polynomial_rust, bytes_to_blob,
-        compute_blob_kzg_proof_rust, compute_kzg_proof_rust, compute_powers,
-        evaluate_polynomial_in_evaluation_form_rust, load_trusted_setup_filename_rust,
-        verify_blob_kzg_proof_batch_rust, verify_blob_kzg_proof_rust, verify_kzg_proof_rust,
-    };
-    use blst_rust::types::{
-        fft_settings::FsFFTSettings, fr::FsFr, g1::FsG1, g2::FsG2, kzg_settings::FsKZGSettings,
-        poly::FsPoly,
-    };
     use kzg_bench::tests::eip_4844::{
         blob_to_kzg_commitment_test, bytes_to_bls_field_test,
         compute_and_verify_blob_kzg_proof_fails_with_incorrect_proof_test,
@@ -24,6 +14,16 @@ mod tests {
         test_vectors_compute_blob_kzg_proof, test_vectors_compute_kzg_proof,
         test_vectors_verify_blob_kzg_proof, test_vectors_verify_blob_kzg_proof_batch,
         test_vectors_verify_kzg_proof,
+    };
+    use rust_kzg_blst::eip_4844::{
+        blob_to_kzg_commitment_rust, blob_to_polynomial_rust, bytes_to_blob,
+        compute_blob_kzg_proof_rust, compute_kzg_proof_rust, compute_powers,
+        evaluate_polynomial_in_evaluation_form_rust, load_trusted_setup_filename_rust,
+        verify_blob_kzg_proof_batch_rust, verify_blob_kzg_proof_rust, verify_kzg_proof_rust,
+    };
+    use rust_kzg_blst::types::{
+        fft_settings::FsFFTSettings, fr::FsFr, g1::FsG1, g2::FsG2, kzg_settings::FsKZGSettings,
+        poly::FsPoly,
     };
 
     #[test]

--- a/blst/tests/fft_fr.rs
+++ b/blst/tests/fft_fr.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use blst_rust::fft_fr::{fft_fr_fast, fft_fr_slow};
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
     use kzg_bench::tests::fft_fr::{compare_sft_fft, inverse_fft, roundtrip_fft, stride_fft};
+    use rust_kzg_blst::fft_fr::{fft_fr_fast, fft_fr_slow};
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
 
     #[test]
     fn compare_sft_fft_() {

--- a/blst/tests/fft_g1.rs
+++ b/blst/tests/fft_g1.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use blst_rust::consts::G1_GENERATOR;
-    use blst_rust::fft_g1::{fft_g1_fast, fft_g1_slow};
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::g1::FsG1;
     use kzg::G1;
     use kzg_bench::tests::fft_g1::{compare_ft_fft, roundtrip_fft, stride_fft};
+    use rust_kzg_blst::consts::G1_GENERATOR;
+    use rust_kzg_blst::fft_g1::{fft_g1_fast, fft_g1_slow};
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::g1::FsG1;
 
     fn make_data(n: usize) -> Vec<FsG1> {
         if n == 0 {

--- a/blst/tests/fk20_proofs.rs
+++ b/blst/tests/fk20_proofs.rs
@@ -1,15 +1,15 @@
 #[cfg(test)]
 mod tests {
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fk20_multi_settings::FsFK20MultiSettings;
-    use blst_rust::types::fk20_single_settings::FsFK20SingleSettings;
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::g1::FsG1;
-    use blst_rust::types::g2::FsG2;
-    use blst_rust::types::kzg_settings::FsKZGSettings;
-    use blst_rust::types::poly::FsPoly;
-    use blst_rust::utils::generate_trusted_setup;
     use kzg_bench::tests::fk20_proofs::*;
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fk20_multi_settings::FsFK20MultiSettings;
+    use rust_kzg_blst::types::fk20_single_settings::FsFK20SingleSettings;
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::g1::FsG1;
+    use rust_kzg_blst::types::g2::FsG2;
+    use rust_kzg_blst::types::kzg_settings::FsKZGSettings;
+    use rust_kzg_blst::types::poly::FsPoly;
+    use rust_kzg_blst::utils::generate_trusted_setup;
 
     #[test]
     fn test_fk_single() {

--- a/blst/tests/kzg_proofs.rs
+++ b/blst/tests/kzg_proofs.rs
@@ -9,13 +9,13 @@ mod tests {
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
     };
 
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::g1::FsG1;
-    use blst_rust::types::g2::FsG2;
-    use blst_rust::types::kzg_settings::FsKZGSettings;
-    use blst_rust::types::poly::FsPoly;
-    use blst_rust::utils::generate_trusted_setup;
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::g1::FsG1;
+    use rust_kzg_blst::types::g2::FsG2;
+    use rust_kzg_blst::types::kzg_settings::FsKZGSettings;
+    use rust_kzg_blst::types::poly::FsPoly;
+    use rust_kzg_blst::utils::generate_trusted_setup;
 
     #[test]
     pub fn test_proof_single() {

--- a/blst/tests/local_tests/local_poly.rs
+++ b/blst/tests/local_tests/local_poly.rs
@@ -2,8 +2,8 @@ use kzg::{Fr, Poly};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 
-use blst_rust::types::fr::FsFr;
-use blst_rust::types::poly::FsPoly;
+use rust_kzg_blst::types::fr::FsFr;
+use rust_kzg_blst::types::poly::FsPoly;
 
 pub fn create_poly_of_length_ten() {
     let poly = FsPoly::new(10).unwrap();

--- a/blst/tests/poly.rs
+++ b/blst/tests/poly.rs
@@ -3,15 +3,15 @@
 
 #[cfg(test)]
 mod tests {
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::poly::FsPoly;
     use kzg_bench::tests::poly::{
         create_poly_of_length_ten, poly_div_by_zero, poly_div_fast_test, poly_div_long_test,
         poly_div_random, poly_eval_0_check, poly_eval_check, poly_eval_nil_check,
         poly_inverse_simple_0, poly_inverse_simple_1, poly_mul_direct_test, poly_mul_fft_test,
         poly_mul_random, poly_test_div,
     };
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::poly::FsPoly;
 
     // Local tests
     // #[test]

--- a/blst/tests/recovery.rs
+++ b/blst/tests/recovery.rs
@@ -7,9 +7,9 @@ mod tests {
     // uncomment to use the local tests
     //use crate::local_recovery::{recover_random, recover_simple};
 
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::poly::FsPoly;
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::poly::FsPoly;
 
     // Shared tests
     #[test]

--- a/blst/tests/zero_poly.rs
+++ b/blst/tests/zero_poly.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use blst_rust::types::fft_settings::FsFFTSettings;
-    use blst_rust::types::fr::FsFr;
-    use blst_rust::types::poly::FsPoly;
     use kzg_bench::tests::zero_poly::{
         check_test_data, reduce_partials_random, test_reduce_partials, zero_poly_252,
         zero_poly_all_but_one, zero_poly_known, zero_poly_random,
     };
+    use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+    use rust_kzg_blst::types::fr::FsFr;
+    use rust_kzg_blst::types::poly::FsPoly;
 
     #[test]
     fn test_reduce_partials_() {

--- a/mcl/kzg-bench/Cargo.toml
+++ b/mcl/kzg-bench/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "mcl_kzg_bench"
+name = "rust-kzg-mcl-bench"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcl_rust = { path = '../kzg' }
+rust-kzg-mcl = { path = '../kzg' }
 blst = {'git' = 'https://github.com/supranational/blst.git'}
 kzg = { path = "../../kzg" }
 kzg-bench = { path = "../../kzg-bench" }

--- a/mcl/kzg-bench/benches/shared_das.rs
+++ b/mcl/kzg-bench/benches/shared_das.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::das::bench_das_extension;
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_das_extension_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_eip_4844.rs
+++ b/mcl/kzg-bench/benches/shared_eip_4844.rs
@@ -1,10 +1,10 @@
-use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
-use mcl_rust::eip_4844::*;
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::kzg10::Polynomial;
-use mcl_rust::kzg_settings::KZGSettings;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::{fr::Fr, g1::G1, g2::G2};
+use rust_kzg_mcl::eip_4844::*;
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::kzg10::Polynomial;
+use rust_kzg_mcl::kzg_settings::KZGSettings;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::eip_4844::bench_eip_4844;

--- a/mcl/kzg-bench/benches/shared_fft.rs
+++ b/mcl/kzg-bench/benches/shared_fft.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fft::{bench_fft_fr, bench_fft_g1};
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::data_types::g1::G1;
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::data_types::g1::G1;
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_fft_fr_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_fk20.rs
+++ b/mcl/kzg-bench/benches/shared_fk20.rs
@@ -1,12 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fk20::*;
-use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::fk20_matrix::{FK20Matrix, FK20SingleMatrix};
-use mcl_rust::kzg10::Polynomial;
-use mcl_rust::kzg_settings::KZGSettings;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::{fr::Fr, g1::G1, g2::G2};
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::fk20_matrix::{FK20Matrix, FK20SingleMatrix};
+use rust_kzg_mcl::kzg10::Polynomial;
+use rust_kzg_mcl::kzg_settings::KZGSettings;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_fk_single_da_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_kzg_proof.rs
+++ b/mcl/kzg-bench/benches/shared_kzg_proof.rs
@@ -1,11 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::kzg::{bench_commit_to_poly, bench_compute_proof_single};
-use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::kzg10::Polynomial;
-use mcl_rust::kzg_settings::KZGSettings;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::{fr::Fr, g1::G1, g2::G2};
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::kzg10::Polynomial;
+use rust_kzg_mcl::kzg_settings::KZGSettings;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_commit_to_poly_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_lincomb.rs
+++ b/mcl/kzg-bench/benches/shared_lincomb.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::lincomb::bench_g1_lincomb;
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::data_types::g1::{g1_linear_combination, G1};
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::data_types::g1::{g1_linear_combination, G1};
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_g1_lincomb_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_poly.rs
+++ b/mcl/kzg-bench/benches/shared_poly.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::poly::bench_new_poly_div;
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::kzg10::Polynomial;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::kzg10::Polynomial;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_new_poly_div_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_recover.rs
+++ b/mcl/kzg-bench/benches/shared_recover.rs
@@ -1,11 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::recover::bench_recover;
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::kzg10::Polynomial;
-
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::kzg10::Polynomial;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_recover_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/benches/shared_zero_poly.rs
+++ b/mcl/kzg-bench/benches/shared_zero_poly.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::zero_poly::bench_zero_poly;
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::fk20_fft::FFTSettings;
-use mcl_rust::kzg10::Polynomial;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::fk20_fft::FFTSettings;
+use rust_kzg_mcl::kzg10::Polynomial;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 
 fn bench_zero_poly_(c: &mut Criterion) {
     assert!(init(CurveType::BLS12_381));

--- a/mcl/kzg-bench/src/fft_common.rs
+++ b/mcl/kzg-bench/src/fft_common.rs
@@ -1,7 +1,7 @@
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::fk20_fft::*;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::fk20_fft::*;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 use std::vec;
 
 #[test]

--- a/mcl/kzg-bench/src/poly.rs
+++ b/mcl/kzg-bench/src/poly.rs
@@ -1,7 +1,7 @@
-use mcl_rust::data_types::fr::Fr;
-use mcl_rust::kzg10::*;
-use mcl_rust::mcl_methods::init;
-use mcl_rust::CurveType;
+use rust_kzg_mcl::data_types::fr::Fr;
+use rust_kzg_mcl::kzg10::*;
+use rust_kzg_mcl::mcl_methods::init;
+use rust_kzg_mcl::CurveType;
 use std::vec;
 
 #[test]

--- a/mcl/kzg-bench/src/shared_tests/bls12_381.rs
+++ b/mcl/kzg-bench/src/shared_tests/bls12_381.rs
@@ -1,14 +1,14 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::bls12_381::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::data_types::g1::g1_linear_combination;
-    use mcl_rust::data_types::g1::G1;
-    use mcl_rust::data_types::g2::G2;
-    use mcl_rust::kzg10::Curve;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::utilities::log_2_byte;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::data_types::g1::g1_linear_combination;
+    use rust_kzg_mcl::data_types::g1::G1;
+    use rust_kzg_mcl::data_types::g2::G2;
+    use rust_kzg_mcl::kzg10::Curve;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::utilities::log_2_byte;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     pub fn log_2_byte_works_() {

--- a/mcl/kzg-bench/src/shared_tests/consts.rs
+++ b/mcl/kzg-bench/src/shared_tests/consts.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod consts_tests {
     use kzg_bench::tests::consts::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::fk20_fft::{
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::fk20_fft::{
         expand_root_of_unity, init_globals, FFTSettings, SCALE_2_ROOT_OF_UNITY,
     };
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     pub fn expand_root_of_unityarr(root: &Fr, _width: usize) -> Result<Vec<Fr>, String> {
         Ok(expand_root_of_unity(root))

--- a/mcl/kzg-bench/src/shared_tests/das.rs
+++ b/mcl/kzg-bench/src/shared_tests/das.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod das_tests {
     use kzg_bench::tests::das::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn das_extension_test_known_() {

--- a/mcl/kzg-bench/src/shared_tests/eip_4844.rs
+++ b/mcl/kzg-bench/src/shared_tests/eip_4844.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::eip_4844::*;
-    use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
-    use mcl_rust::eip_4844::*;
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::kzg10::Polynomial;
-    use mcl_rust::kzg_settings::KZGSettings;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::{fr::Fr, g1::G1, g2::G2};
+    use rust_kzg_mcl::eip_4844::*;
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::kzg10::Polynomial;
+    use rust_kzg_mcl::kzg_settings::KZGSettings;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     pub fn bytes_to_bls_field_test_() {

--- a/mcl/kzg-bench/src/shared_tests/fft_fr.rs
+++ b/mcl/kzg-bench/src/shared_tests/fft_fr.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod fft_fr_tests {
     use kzg_bench::tests::fft_fr::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn compare_sft_fft_() {

--- a/mcl/kzg-bench/src/shared_tests/fft_g1.rs
+++ b/mcl/kzg-bench/src/shared_tests/fft_g1.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod fft_g1_tests {
     use kzg_bench::tests::fft_g1::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::data_types::g1::G1;
-    use mcl_rust::fk20_fft::{make_data, FFTSettings};
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::data_types::g1::G1;
+    use rust_kzg_mcl::fk20_fft::{make_data, FFTSettings};
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn roundtrip_fft_g1_() {

--- a/mcl/kzg-bench/src/shared_tests/finite.rs
+++ b/mcl/kzg-bench/src/shared_tests/finite.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod finite_test {
     use kzg_bench::tests::finite::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn sum_of_two_zeros_is_zero_() {

--- a/mcl/kzg-bench/src/shared_tests/fk20_proofs.rs
+++ b/mcl/kzg-bench/src/shared_tests/fk20_proofs.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::fk20_proofs::*;
-    use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::fk20_matrix::{FK20Matrix, FK20SingleMatrix};
-    use mcl_rust::kzg10::Polynomial;
-    use mcl_rust::kzg_settings::KZGSettings;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::{fr::Fr, g1::G1, g2::G2};
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::fk20_matrix::{FK20Matrix, FK20SingleMatrix};
+    use rust_kzg_mcl::kzg10::Polynomial;
+    use rust_kzg_mcl::kzg_settings::KZGSettings;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn test_fk_single() {

--- a/mcl/kzg-bench/src/shared_tests/kzg_proofs.rs
+++ b/mcl/kzg-bench/src/shared_tests/kzg_proofs.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod kzg_proofs_tests {
     use kzg_bench::tests::kzg_proofs::*;
-    use mcl_rust::data_types::{fr::Fr, g1::G1, g2::G2};
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::kzg10::Polynomial;
-    use mcl_rust::kzg_settings::KZGSettings;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::{fr::Fr, g1::G1, g2::G2};
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::kzg10::Polynomial;
+    use rust_kzg_mcl::kzg_settings::KZGSettings;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn proof_single_() {

--- a/mcl/kzg-bench/src/shared_tests/poly.rs
+++ b/mcl/kzg-bench/src/shared_tests/poly.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod poly_tests {
     use kzg_bench::tests::poly::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::kzg10::Polynomial;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::kzg10::Polynomial;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn create_poly_of_length_ten_() {

--- a/mcl/kzg-bench/src/shared_tests/recover.rs
+++ b/mcl/kzg-bench/src/shared_tests/recover.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod recover_tests {
     use kzg_bench::tests::recover::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::kzg10::Polynomial;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::kzg10::Polynomial;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn recover_simple_() {

--- a/mcl/kzg-bench/src/shared_tests/zero_poly.rs
+++ b/mcl/kzg-bench/src/shared_tests/zero_poly.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod zero_poly_tests {
     use kzg_bench::tests::zero_poly::*;
-    use mcl_rust::data_types::fr::Fr;
-    use mcl_rust::fk20_fft::FFTSettings;
-    use mcl_rust::kzg10::Polynomial;
-    use mcl_rust::mcl_methods::init;
-    use mcl_rust::CurveType;
+    use rust_kzg_mcl::data_types::fr::Fr;
+    use rust_kzg_mcl::fk20_fft::FFTSettings;
+    use rust_kzg_mcl::kzg10::Polynomial;
+    use rust_kzg_mcl::mcl_methods::init;
+    use rust_kzg_mcl::CurveType;
 
     #[test]
     fn test_reduce_partials_() {

--- a/mcl/kzg-bench/src/test.rs
+++ b/mcl/kzg-bench/src/test.rs
@@ -1,12 +1,12 @@
 // use std::{mem, vec};
-use mcl_rust::mcl_methods::*;
+use rust_kzg_mcl::mcl_methods::*;
 use std::mem;
-// use mcl_rust::utilities::*;
-// use mcl_rust::kzg10::*;
-use mcl_rust::data_types::{fp::*, fp2::*, fr::*, g1::*, g2::*, gt::*};
-use mcl_rust::CurveType;
-// use mcl_rust::fk20_fft::*;
-// use mcl_rust::fk20_matrix::*;
+// use rust_kzg_mcl::utilities::*;
+// use rust_kzg_mcl::kzg10::*;
+use rust_kzg_mcl::data_types::{fp::*, fp2::*, fr::*, g1::*, g2::*, gt::*};
+use rust_kzg_mcl::CurveType;
+// use rust_kzg_mcl::fk20_fft::*;
+// use rust_kzg_mcl::fk20_matrix::*;
 
 #[test]
 #[allow(clippy::many_single_char_names)]

--- a/mcl/kzg/Cargo.toml
+++ b/mcl/kzg/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcl_rust"
+name = "rust-kzg-mcl"
 version = "0.0.1"
 authors = ["MITSUNARI Shigeo <herumi@nifty.com>"]
 description = "a wrapper class/function of a pairing library; https://github.com/herumi/mcl"

--- a/mcl/kzg/csharp.patch
+++ b/mcl/kzg/csharp.patch
@@ -16,7 +16,7 @@ index d5fa3dc..0a77983 100644
  FIELD_ELEMENTS_PER_BLOB ?= 4096
  INCLUDE_DIRS = ../../src ../../blst/bindings
 -TARGETS = ckzg.c ../../src/c_kzg_4844.c ../../blst/$(BLST_OBJ)
-+TARGETS = ckzg.c ../../../../../target/release/libmcl_rust.a
++TARGETS = ckzg.c ../../../../../target/release/rust_kzg_mcl.a
  
  CFLAGS += -O2 -Wall -Wextra -shared
  CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)

--- a/mcl/kzg/go.patch
+++ b/mcl/kzg/go.patch
@@ -24,7 +24,7 @@ index aa7f141..1357122 100644
 +// #endif
 +// #include <stdlib.h>
 +// #include "c_kzg_4844.h"
-+// #cgo LDFLAGS: -L${SRCDIR}/../../../../../target/release -L${SRCDIR}/../../lib -lmcl_rust -lstdc++ -lblst -lm
++// #cgo LDFLAGS: -L${SRCDIR}/../../../../../target/release -L${SRCDIR}/../../lib -l:rust_kzg_mcl.a -lstdc++ -lblst -lm
  import "C"
  
  import (

--- a/mcl/kzg/java.patch
+++ b/mcl/kzg/java.patch
@@ -15,7 +15,7 @@ index 4eb21ce..184e501 100644
  INCLUDE_DIRS = ../../src ../../blst/bindings
 
 -TARGETS=c_kzg_4844_jni.c ../../src/c_kzg_4844.c ../../lib/libblst.a
-+TARGETS=c_kzg_4844_jni.c ../../../../../target/release/libmcl_rust.a
++TARGETS=c_kzg_4844_jni.c ../../../../../target/release/rust_kzg_mcl.a
 
  CC_FLAGS=
  OPTIMIZATION_LEVEL=-O2

--- a/mcl/kzg/nodejs.patch
+++ b/mcl/kzg/nodejs.patch
@@ -1,12 +1,13 @@
-From a88f94c415c9ccc82437b189691e65db3fbd2639 Mon Sep 17 00:00:00 2001
+From 344b90e309d605d454cbb962da0531bcb062b11a Mon Sep 17 00:00:00 2001
 From: belijzajac <tautvydas749@gmail.com>
-Date: Tue, 11 Apr 2023 17:42:08 +0300
+Date: Sat, 17 Jun 2023 19:16:04 +0300
 Subject: [PATCH] Update linking
 
 ---
- bindings/node.js/Makefile    | 1 -
- bindings/node.js/binding.gyp | 6 ++++--
- 2 files changed, 4 insertions(+), 3 deletions(-)
+ bindings/node.js/Makefile    |  1 -
+ bindings/node.js/binding.gyp | 37 +++++-------------------------------
+ bindings/node.js/src/kzg.cxx |  4 ++++
+ 3 files changed, 9 insertions(+), 33 deletions(-)
 
 diff --git a/bindings/node.js/Makefile b/bindings/node.js/Makefile
 index fdf1618..34e54df 100644
@@ -21,28 +22,71 @@ index fdf1618..34e54df 100644
  	@# Build the bindings
  	@$(YARN) node-gyp --loglevel=warn configure
 diff --git a/bindings/node.js/binding.gyp b/bindings/node.js/binding.gyp
-index 69be3ef..8213dd7 100644
+index 69be3ef..349ac0b 100644
 --- a/bindings/node.js/binding.gyp
 +++ b/bindings/node.js/binding.gyp
-@@ -4,14 +4,16 @@
+@@ -3,44 +3,17 @@
+     {
        "target_name": "kzg",
        "sources": [
-         "src/kzg.cxx",
+-        "src/kzg.cxx",
 -        "deps/blst/src/server.c",
 -        "deps/c-kzg/c_kzg_4844.c"
-+        "deps/blst/src/server.c"
++        "src/kzg.cxx"
        ],
        "include_dirs": [
          "<(module_root_dir)/deps/blst/bindings",
          "<(module_root_dir)/deps/c-kzg",
          "<!@(node -p \"require('node-addon-api').include\")"
        ],
+-      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
+-      "conditions": [
+-        ["OS!='win'", {
+-          "sources": ["deps/blst/build/assembly.S"],
+-          "defines": ["FIELD_ELEMENTS_PER_BLOB=<!(echo ${FIELD_ELEMENTS_PER_BLOB:-4096})"],
+-          "cflags_cc": [
+-            "-std=c++17",
+-            "-fPIC"
+-          ]
+-        }],
+-        ["OS=='win'", {
+-          "sources": ["deps/blst/build/win64/*-x86_64.asm"],
+-          "defines": [
+-            "_CRT_SECURE_NO_WARNINGS",
+-            "FIELD_ELEMENTS_PER_BLOB=<!(powershell -Command \"if ($env:FIELD_ELEMENTS_PER_BLOB) { $env:FIELD_ELEMENTS_PER_BLOB } else { 4096 }\")"
+-          ],
+-          "msbuild_settings": {
+-            "ClCompile": {
+-              "AdditionalOptions": ["/std:c++17"]
+-            }
+-          }
+-        }],
+-        ["OS=='mac'", {
+-          "xcode_settings": {
+-            "CLANG_CXX_LIBRARY": "libc++",
+-            "MACOSX_DEPLOYMENT_TARGET": "13.0"
+-          }
+-        }]
+-      ]
 +      "libraries": [
-+        "<(module_root_dir)/../../../../../target/release/libmcl_rust.a"
++        "<(module_root_dir)/../../../../../target/release/rust_kzg_mcl.a"
 +      ],
-       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
-       "conditions": [
-         ["OS!='win'", {
++      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]
+     }
+   ]
+ }
+diff --git a/bindings/node.js/src/kzg.cxx b/bindings/node.js/src/kzg.cxx
+index 871aa90..f89b1e3 100644
+--- a/bindings/node.js/src/kzg.cxx
++++ b/bindings/node.js/src/kzg.cxx
+@@ -1,3 +1,7 @@
++#ifndef FIELD_ELEMENTS_PER_BLOB
++#define FIELD_ELEMENTS_PER_BLOB 4096
++#endif
++
+ #include "blst.h"
+ #include "c_kzg_4844.h"
+ #include <iostream>
 -- 
-2.40.0
+2.40.1
 

--- a/mcl/kzg/python.patch
+++ b/mcl/kzg/python.patch
@@ -40,7 +40,7 @@ index bf969cb..9179129 100644
 -                library_dirs=["../../lib"],
 -                libraries=["blst"])])
 +                library_dirs=["../../lib", "../../../../../target/release"],
-+                libraries=["mcl_rust", "stdc++"])])
++                libraries=[":rust_kzg_mcl.a", "stdc++"])])
  
  if __name__ == "__main__":
      main()

--- a/mcl/kzg/run-c-kzg-4844-benches.sh
+++ b/mcl/kzg/run-c-kzg-4844-benches.sh
@@ -28,7 +28,7 @@ done
 
 ###################### building static libs ######################
 
-print_msg "Compiling libmcl_rust"
+print_msg "Compiling rust-kzg-mcl"
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
   cargo rustc --release --crate-type=staticlib --features=parallel
@@ -36,6 +36,8 @@ else
   print_msg "Using non-parallel version"
   cargo rustc --release --crate-type=staticlib
 fi
+
+mv ../../target/release/librust_kzg_mcl.a ../../target/release/rust_kzg_mcl.a
 
 ###################### cloning c-kzg-4844 ######################
 

--- a/mcl/kzg/run-c-kzg-4844-tests.sh
+++ b/mcl/kzg/run-c-kzg-4844-tests.sh
@@ -28,7 +28,7 @@ done
 
 ###################### building static libs ######################
 
-print_msg "Compiling libmcl_rust"
+print_msg "Compiling rust-kzg-mcl"
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
   cargo rustc --release --crate-type=staticlib --features=parallel
@@ -36,6 +36,8 @@ else
   print_msg "Using non-parallel version"
   cargo rustc --release --crate-type=staticlib
 fi
+
+mv ../../target/release/librust_kzg_mcl.a ../../target/release/rust_kzg_mcl.a
 
 ###################### cloning c-kzg-4844 ######################
 

--- a/mcl/kzg/rust.patch
+++ b/mcl/kzg/rust.patch
@@ -73,7 +73,7 @@ index d2dba36..ac4153f 100644
      // Finally, tell cargo this provides ckzg
 -    println!("cargo:rustc-link-lib=ckzg");
 +    println!("cargo:rustc-link-search={}", rust_kzg_target_dir.display());
-+    println!("cargo:rustc-link-lib=mcl_rust");
++    println!("cargo:rustc-link-arg=-l:rust_kzg_mcl.a");
  }
  
  fn make_bindings<P>(

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Currently, the ECC backend is set by pointing Cargo to the corresponding crate:
 
 ```
 [dependencies]
-kzg = { git = "https://github.com/sifraitech/rust-kzg.git", package = "blst_rust" }
+kzg = { git = "https://github.com/sifraitech/rust-kzg.git", package = "rust-kzg-blst" }
 kzg_traits = { git = "https://github.com/sifraitech/rust-kzg.git", package = "kzg" }
 ```
 

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -51,6 +51,7 @@ cd rust-kzg || exit
 # 2.2. prepare rust-kzg with blst backend and c-kzg-4844
 cd blst || exit
 cargo rustc --release --crate-type=staticlib --features=parallel
+mv ../target/release/librust_kzg_blst.a ../target/release/rust_kzg_blst.a
 git clone https://github.com/ethereum/c-kzg-4844.git
 cd c-kzg-4844 || exit
 git -c advice.detachedHead=false checkout 5703f6f3536b7692616bc289ac3f3867ab8db9d8 # TODO: keep this updated
@@ -128,7 +129,7 @@ do
 
   # 3.10. rust-kzg with mcl backend (parallel)
   print_msg "rust-kzg with mcl backend (parallel)" ../"$paste_file"
-  taskset --cpu-list "${taskset_cpu_list[$i]}" cargo bench --manifest-path mcl/kzg-bench/Cargo.toml --features mcl_rust/parallel >> ../"$paste_file"
+  taskset --cpu-list "${taskset_cpu_list[$i]}" cargo bench --manifest-path mcl/kzg-bench/Cargo.toml --features rust-kzg-mcl/parallel >> ../"$paste_file"
 
   # 3.11. rust binding (rust-kzg with blst backend)
   print_msg "rust binding (rust-kzg with blst backend)" ../"$paste_file"

--- a/zkcrypto/Cargo.toml
+++ b/zkcrypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zkcrypto"
+name = "rust-kzg-zkcrypto"
 version = "0.1.0"
 edition = "2021"
 

--- a/zkcrypto/benches/das.rs
+++ b/zkcrypto/benches/das.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::das::bench_das_extension;
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_das_extension_(c: &mut Criterion) {
     bench_das_extension::<blsScalar, ZkFFTSettings>(c);

--- a/zkcrypto/benches/eip_4844.rs
+++ b/zkcrypto/benches/eip_4844.rs
@@ -1,15 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::eip_4844::bench_eip_4844;
-use zkcrypto::eip_4844::{
+use rust_kzg_zkcrypto::eip_4844::{
     blob_to_kzg_commitment, bytes_to_blob, compute_blob_kzg_proof, compute_kzg_proof,
     load_trusted_setup, verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
 };
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::kzg_proofs::KZGSettings;
-use zkcrypto::kzg_types::ZkG2Projective;
-use zkcrypto::poly::KzgPoly;
-use zkcrypto::utils::ZkG1Projective;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::kzg_proofs::KZGSettings;
+use rust_kzg_zkcrypto::kzg_types::ZkG2Projective;
+use rust_kzg_zkcrypto::poly::KzgPoly;
+use rust_kzg_zkcrypto::utils::ZkG1Projective;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_eip_4844_(c: &mut Criterion) {
     bench_eip_4844::<blsScalar, ZkG1Projective, ZkG2Projective, KzgPoly, ZkFFTSettings, KZGSettings>(

--- a/zkcrypto/benches/fft.rs
+++ b/zkcrypto/benches/fft.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fft::{bench_fft_fr, bench_fft_g1};
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::kzg_types::ZkG1Projective;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::kzg_types::ZkG1Projective;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_fft_fr_(c: &mut Criterion) {
     bench_fft_fr::<blsScalar, ZkFFTSettings>(c);

--- a/zkcrypto/benches/fk20.rs
+++ b/zkcrypto/benches/fk20.rs
@@ -1,12 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fk20::{bench_fk_multi_da, bench_fk_single_da};
 
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::fk20::{ZkFK20MultiSettings, ZkFK20SingleSettings};
-use zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
-use zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
-use zkcrypto::poly::ZPoly;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::fk20::{ZkFK20MultiSettings, ZkFK20SingleSettings};
+use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
+use rust_kzg_zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
+use rust_kzg_zkcrypto::poly::ZPoly;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_fk_single_da_(c: &mut Criterion) {
     bench_fk_single_da::<

--- a/zkcrypto/benches/kzg.rs
+++ b/zkcrypto/benches/kzg.rs
@@ -1,11 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::kzg::{bench_commit_to_poly, bench_compute_proof_single};
 
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
-use zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
-use zkcrypto::poly::ZPoly;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
+use rust_kzg_zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
+use rust_kzg_zkcrypto::poly::ZPoly;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_commit_to_poly_(c: &mut Criterion) {
     bench_commit_to_poly::<

--- a/zkcrypto/benches/lincomb.rs
+++ b/zkcrypto/benches/lincomb.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::lincomb::bench_g1_lincomb;
-use zkcrypto::curve::multiscalar_mul::msm_variable_base;
-use zkcrypto::kzg_types::ZkG1Projective;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::curve::multiscalar_mul::msm_variable_base;
+use rust_kzg_zkcrypto::kzg_types::ZkG1Projective;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn g1_linear_combination(
     out: &mut ZkG1Projective,

--- a/zkcrypto/benches/poly.rs
+++ b/zkcrypto/benches/poly.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::poly::bench_new_poly_div;
-use zkcrypto::poly::ZPoly;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::poly::ZPoly;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_new_poly_div_(c: &mut Criterion) {
     bench_new_poly_div::<blsScalar, ZPoly>(c);

--- a/zkcrypto/benches/recover.rs
+++ b/zkcrypto/benches/recover.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::recover::bench_recover;
 
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::poly::ZPoly;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::poly::ZPoly;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 pub fn bench_recover_(c: &mut Criterion) {
     bench_recover::<blsScalar, ZkFFTSettings, ZPoly, ZPoly>(c)

--- a/zkcrypto/benches/zero_poly.rs
+++ b/zkcrypto/benches/zero_poly.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::zero_poly::bench_zero_poly;
-use zkcrypto::fftsettings::ZkFFTSettings;
-use zkcrypto::poly::ZPoly;
-use zkcrypto::zkfr::blsScalar;
+use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+use rust_kzg_zkcrypto::poly::ZPoly;
+use rust_kzg_zkcrypto::zkfr::blsScalar;
 
 fn bench_zero_poly_(c: &mut Criterion) {
     bench_zero_poly::<blsScalar, ZkFFTSettings, ZPoly>(c);

--- a/zkcrypto/tests/bls12_381.rs
+++ b/zkcrypto/tests/bls12_381.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::bls12_381::*;
-    use zkcrypto::kzg_types::{pairings_verify, ZkG1Projective, ZkG2Projective};
-    use zkcrypto::utils::log_2_byte;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::kzg_types::{pairings_verify, ZkG1Projective, ZkG2Projective};
+    use rust_kzg_zkcrypto::utils::log_2_byte;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     pub fn log_2_byte_works_() {

--- a/zkcrypto/tests/consts.rs
+++ b/zkcrypto/tests/consts.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::consts::*;
-    use zkcrypto::consts::{expand_root_of_unity, SCALE2_ROOT_OF_UNITY};
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::consts::{expand_root_of_unity, SCALE2_ROOT_OF_UNITY};
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn roots_of_unity_out_of_bounds_fails_() {

--- a/zkcrypto/tests/das.rs
+++ b/zkcrypto/tests/das.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::das::{das_extension_test_known, das_extension_test_random};
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn das_extension_test_known_() {

--- a/zkcrypto/tests/eip_4844.rs
+++ b/zkcrypto/tests/eip_4844.rs
@@ -10,17 +10,17 @@ mod tests {
         compute_and_verify_kzg_proof_round_trip_test, compute_kzg_proof_test, compute_powers_test,
         verify_kzg_proof_batch_fails_with_incorrect_proof_test, verify_kzg_proof_batch_test,
     };
-    use zkcrypto::eip_4844::{
+    use rust_kzg_zkcrypto::eip_4844::{
         blob_to_kzg_commitment, blob_to_polynomial, bytes_to_blob, compute_blob_kzg_proof,
         compute_kzg_proof, compute_powers, evaluate_polynomial_in_evaluation_form,
         load_trusted_setup, verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
     };
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::kzg_proofs::KZGSettings;
-    use zkcrypto::kzg_types::ZkG2Projective;
-    use zkcrypto::poly::KzgPoly;
-    use zkcrypto::utils::ZkG1Projective;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::kzg_proofs::KZGSettings;
+    use rust_kzg_zkcrypto::kzg_types::ZkG2Projective;
+    use rust_kzg_zkcrypto::poly::KzgPoly;
+    use rust_kzg_zkcrypto::utils::ZkG1Projective;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     pub fn bytes_to_bls_field_test_() {

--- a/zkcrypto/tests/fft_fr.rs
+++ b/zkcrypto/tests/fft_fr.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::fft_fr::*;
-    use zkcrypto::fft_fr::{fft_fr_fast, fft_fr_slow};
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fft_fr::{fft_fr_fast, fft_fr_slow};
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn compare_sft_fft_() {

--- a/zkcrypto/tests/fft_g1.rs
+++ b/zkcrypto/tests/fft_g1.rs
@@ -2,11 +2,11 @@
 mod tests {
     use kzg::G1;
     use kzg_bench::tests::fft_g1::{compare_ft_fft, roundtrip_fft, stride_fft};
-    use zkcrypto::fft_g1::{fft_g1_fast, fft_g1_slow};
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::kzg_types::ZkG1Projective;
-    use zkcrypto::kzg_types::G1_GENERATOR;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fft_g1::{fft_g1_fast, fft_g1_slow};
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::kzg_types::ZkG1Projective;
+    use rust_kzg_zkcrypto::kzg_types::G1_GENERATOR;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     fn make_data(n: usize) -> Vec<ZkG1Projective> {
         if n == 0 {

--- a/zkcrypto/tests/fk20.rs
+++ b/zkcrypto/tests/fk20.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::fk20_proofs::*;
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::fk20::{ZkFK20MultiSettings, ZkFK20SingleSettings};
-    use zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
-    use zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
-    use zkcrypto::poly::ZPoly;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::fk20::{ZkFK20MultiSettings, ZkFK20SingleSettings};
+    use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
+    use rust_kzg_zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
+    use rust_kzg_zkcrypto::poly::ZPoly;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn test_fk_single() {

--- a/zkcrypto/tests/kzg_proofs.rs
+++ b/zkcrypto/tests/kzg_proofs.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::kzg_proofs::*;
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
-    use zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
-    use zkcrypto::poly::ZPoly;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, KZGSettings};
+    use rust_kzg_zkcrypto::kzg_types::{ZkG1Projective, ZkG2Projective};
+    use rust_kzg_zkcrypto::poly::ZPoly;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn test_proof_single() {

--- a/zkcrypto/tests/poly.rs
+++ b/zkcrypto/tests/poly.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use kzg_bench::tests::poly::*;
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::poly::ZPoly;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::poly::ZPoly;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn create_poly_of_length_ten_() {

--- a/zkcrypto/tests/recover.rs
+++ b/zkcrypto/tests/recover.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod recover_tests {
     use kzg_bench::tests::recover::*;
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::poly::ZPoly;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::poly::ZPoly;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn recover_simple_() {

--- a/zkcrypto/tests/zero_poly.rs
+++ b/zkcrypto/tests/zero_poly.rs
@@ -4,9 +4,9 @@ mod tests {
         check_test_data, reduce_partials_random, test_reduce_partials, zero_poly_252,
         zero_poly_all_but_one, zero_poly_known, zero_poly_random,
     };
-    use zkcrypto::fftsettings::ZkFFTSettings;
-    use zkcrypto::poly::ZPoly;
-    use zkcrypto::zkfr::blsScalar;
+    use rust_kzg_zkcrypto::fftsettings::ZkFFTSettings;
+    use rust_kzg_zkcrypto::poly::ZPoly;
+    use rust_kzg_zkcrypto::zkfr::blsScalar;
 
     #[test]
     fn test_reduce_partials_() {


### PR DESCRIPTION
* Addresses the issue mentioned in #228 
* Fixes the issue of manually renaming released binaries for git patch to work. Now, instead of requiring the binary to start with the `lib` prefix for `-l` to function properly, you can simply use `-l:` without changing the binary name.