### PR TITLE
Fix features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ jobs:
 
       - name: "[blst] Build Linux"
         run: |
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=blst-portable
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu -C target-cpu=x86-64 --crate-type=staticlib
           mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/non-parallel/rust_kzg_blst.a
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=blst-force-adx
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu -C target-cpu=x86-64 -C target-feature=+adx --crate-type=staticlib
           mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/non-parallel-force-adx/rust_kzg_blst.a
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=parallel,blst-portable
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu -C target-cpu=x86-64 --crate-type=staticlib --features=parallel
           mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/parallel/rust_kzg_blst.a
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu --crate-type=staticlib --features=parallel,blst-force-adx
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-unknown-linux-gnu -C target-cpu=x86-64 -C target-feature=+adx --crate-type=staticlib --features=parallel
           mv target/x86_64-unknown-linux-gnu/release/librust_kzg_blst.a staging/linux/parallel-force-adx/rust_kzg_blst.a
 
       - name: "[blst] Compress Linux artifacts"
@@ -53,13 +53,13 @@ jobs:
 
       - name: "[blst] Build Windows"
         run: |
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=blst-portable
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu -C target-cpu=x86-64 --crate-type=staticlib
           mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/non-parallel/rust_kzg_blst.a
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=blst-force-adx
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu -C target-cpu=x86-64 -C target-feature=+adx --crate-type=staticlib
           mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/non-parallel-force-adx/rust_kzg_blst.a
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=parallel,blst-portable
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu -C target-cpu=x86-64 --crate-type=staticlib --features=parallel
           mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/parallel/rust_kzg_blst.a
-          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu --crate-type=staticlib --features=parallel,blst-force-adx
+          cargo rustc --manifest-path blst/Cargo.toml --release --target x86_64-pc-windows-gnu -C target-cpu=x86-64 -C target-feature=+adx --crate-type=staticlib --features=parallel
           mv target/x86_64-pc-windows-gnu/release/librust_kzg_blst.a staging/windows/parallel-force-adx/rust_kzg_blst.a
 
       - name: "[blst] Compress Windows artifacts"

--- a/blst/Cargo.toml
+++ b/blst/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# TODO: Use `std` feature once https://github.com/supranational/blst/pull/150 or similar upstreamed
 blst = { 'git' = 'https://github.com/supranational/blst.git' }
 kzg = { path = "../kzg", default-features = false }
 libc = { version = "0.2.137", default-features = false }
@@ -24,7 +23,6 @@ rand = "0.8.4"
 default = [
     "std",
     "rand",
-    "blst-default"
 ]
 std = [
     "kzg/std",
@@ -40,18 +38,6 @@ parallel = [
     "dep:num_cpus",
 ]
 minimal-spec = ["kzg/minimal-spec", "kzg-bench/minimal-spec"]
-
-# By default, compile with ADX extension if the host supports it.
-# Binary can be executed on systems similar to the host.
-blst-default = ["blst/default"]
-
-# Compile in portable mode, without ISA extensions.
-# Binary can be executed on all systems.
-blst-portable = ["blst/portable"]
-
-# Enable ADX even if the host CPU doesn't support it.
-# Binary can be executed on Broadwell+ and Ryzen+ systems.
-blst-force-adx = ["blst/force-adx"]
 
 [[bench]]
 name = "das"

--- a/blst/Cargo.toml
+++ b/blst/Cargo.toml
@@ -12,7 +12,7 @@ once_cell = { version = "1.4.0", features = ["critical-section"], default-featur
 rand = { version = "0.8.4", optional = true }
 rayon = { version = "1.5.1", optional = true }
 smallvec = { version = "1.10.0", features = ["const_generics"] }
-hex = "0.4.2"
+hex = { version = "0.4.2", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 criterion = "0.4.0"
@@ -25,6 +25,7 @@ default = [
     "rand",
 ]
 std = [
+    "hex/std",
     "kzg/std",
     "libc/std",
     "once_cell/std",


### PR DESCRIPTION
First commit removes features of `blst` that shouldn't be necessary (and shouldn't exist in `blst` in the first place) as described in https://github.com/sifraitech/rust-kzg/pull/233#discussion_r1336346607.

Second commit fixes regression from https://github.com/sifraitech/rust-kzg/pull/232 that caused `hex` dependency to pull standard library in (annoyingly `wasm32-unknown-unknown` does have a standard library, although an incomplete one, so it didn't cause CI failure).