### PR TITLE
zkcrypto - impl missing traits

### DIFF
--- a/arkworks/src/kzg_types.rs
+++ b/arkworks/src/kzg_types.rs
@@ -954,13 +954,15 @@ impl G1AffineTrait<ArkG1, ArkFp> for ArkG1Affine {
         self.aff.is_zero()
     }
 
-    const ZERO: Self = Self {
-        aff: G1Affine {
-            x: ArkFp::ZERO.0,
-            y: ArkFp::ZERO.0,
-            infinity: true,
-        },
-    };
+    fn zero() -> Self {
+        Self {
+            aff: G1Affine {
+                x: ArkFp::ZERO.0,
+                y: ArkFp::ZERO.0,
+                infinity: true,
+            },
+        }
+    }
 
     fn x_mut(&mut self) -> &mut ArkFp {
         unsafe { core::mem::transmute(&mut self.aff.x) }

--- a/blst/src/types/g1.rs
+++ b/blst/src/types/g1.rs
@@ -283,18 +283,20 @@ impl G1LinComb<FsFr, FsFp, FsG1Affine> for FsG1 {
 pub struct FsG1Affine(pub blst_p1_affine);
 
 impl G1Affine<FsG1, FsFp> for FsG1Affine {
-    const ZERO: Self = Self(blst_p1_affine {
-        x: {
-            blst_fp {
-                l: [0, 0, 0, 0, 0, 0],
-            }
-        },
-        y: {
-            blst_fp {
-                l: [0, 0, 0, 0, 0, 0],
-            }
-        },
-    });
+    fn zero() -> Self {
+        Self(blst_p1_affine {
+            x: {
+                blst_fp {
+                    l: [0, 0, 0, 0, 0, 0],
+                }
+            },
+            y: {
+                blst_fp {
+                    l: [0, 0, 0, 0, 0, 0],
+                }
+            },
+        })
+    }
 
     fn into_affine(g1: &FsG1) -> Self {
         let mut ret: Self = Default::default();

--- a/constantine/src/types/g1.rs
+++ b/constantine/src/types/g1.rs
@@ -325,18 +325,20 @@ impl Debug for CtG1Affine {
 }
 
 impl G1Affine<CtG1, CtFp> for CtG1Affine {
-    const ZERO: Self = Self(bls12_381_g1_aff {
-        x: {
-            bls12_381_fp {
-                limbs: [0, 0, 0, 0, 0, 0],
-            }
-        },
-        y: {
-            bls12_381_fp {
-                limbs: [0, 0, 0, 0, 0, 0],
-            }
-        },
-    });
+    fn zero() -> Self {
+        Self(bls12_381_g1_aff {
+            x: {
+                bls12_381_fp {
+                    limbs: [0, 0, 0, 0, 0, 0],
+                }
+            },
+            y: {
+                bls12_381_fp {
+                    limbs: [0, 0, 0, 0, 0, 0],
+                }
+            },
+        })
+    }
 
     fn into_affine(g1: &CtG1) -> Self {
         let mut ret: Self = Default::default();

--- a/kzg-bench/src/tests/msm/batch_adder.rs
+++ b/kzg-bench/src/tests/msm/batch_adder.rs
@@ -2,7 +2,7 @@ use kzg::{msm::arkmsm::batch_adder::BatchAdder, G1Affine, G1Fp, G1};
 
 pub fn test_phase_one_zero_or_neg<TG1: G1, TGFp: G1Fp, TG1Affine: G1Affine<TG1, TGFp>>() {
     let mut batch_adder = BatchAdder::<TG1, TGFp, TG1Affine>::new(4);
-    batch_adder.batch_add_phase_one(&TG1Affine::ZERO, &TG1Affine::ZERO, 0);
+    batch_adder.batch_add_phase_one(&TG1Affine::zero(), &TG1Affine::zero(), 0);
 
     let p_rand = TG1::rand();
     let p_affine = TG1Affine::into_affine(&p_rand);
@@ -49,7 +49,7 @@ pub fn test_phase_one_p_add_q_twice<TG1: G1, TGFp: G1Fp, TG1Affine: G1Affine<TG1
 pub fn test_phase_two_zero_add_p<TG1: G1, TGFp: G1Fp, TG1Affine: G1Affine<TG1, TGFp>>() {
     let mut batch_adder = BatchAdder::<TG1, TGFp, TG1Affine>::new(4);
     let p = TG1Affine::into_affine(&TG1::rand());
-    let mut acc = G1Affine::ZERO;
+    let mut acc = G1Affine::zero();
     batch_adder.batch_add_phase_two(&mut acc, &p, 0);
     assert_eq!(acc, p);
 }
@@ -61,7 +61,7 @@ pub fn test_phase_two_p_add_neg<TG1: G1, TGFp: G1Fp, TG1Affine: G1Affine<TG1, TG
     p.y_mut().neg_assign();
 
     batch_adder.batch_add_phase_two(&mut acc, &p, 0);
-    assert_eq!(acc, G1Affine::ZERO);
+    assert_eq!(acc, G1Affine::zero());
 }
 
 pub fn test_phase_two_p_add_q<TG1: G1, TGFp: G1Fp, TG1Affine: G1Affine<TG1, TGFp>>() {

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -206,7 +206,7 @@ pub trait G1Fp: Clone + Default + Sync + Copy + PartialEq + Debug + Send {
 pub trait G1Affine<TG1: G1, TG1Fp: G1Fp>:
     Clone + Default + PartialEq + Sync + Copy + Send + Debug
 {
-    const ZERO: Self;
+    fn zero() -> Self;
 
     fn into_affine(g1: &TG1) -> Self;
 
@@ -242,11 +242,11 @@ pub trait G1Affine<TG1: G1, TG1Fp: G1Fp>:
 
     // Return whether Affine is zero
     fn is_zero(&self) -> bool {
-        *self == Self::ZERO
+        *self == Self::zero()
     }
 
     fn set_zero(&mut self) {
-        *self = Self::ZERO;
+        *self = Self::zero();
     }
 }
 

--- a/kzg/src/msm/arkmsm/bucket_msm.rs
+++ b/kzg/src/msm/arkmsm/bucket_msm.rs
@@ -64,12 +64,12 @@ impl<
             bucket_bits,
             max_batch_cnt,
             max_collision_cnt,
-            buckets: vec![TG1Affine::ZERO; bucket_size as usize],
+            buckets: vec![TG1Affine::zero(); bucket_size as usize],
 
             bitmap: Bitmap::new(bucket_size as usize / 32),
             batch_buckets_and_points: Vec::with_capacity(batch_size as usize),
             collision_buckets_and_points: Vec::with_capacity(max_collision_cnt as usize),
-            cur_points: vec![TG1Affine::ZERO; batch_size as usize],
+            cur_points: vec![TG1Affine::zero(); batch_size as usize],
 
             batch_adder: BatchAdder::new(batch_adder_size as usize),
             _p: PhantomData,
@@ -257,8 +257,8 @@ impl<
         let window_starts: Vec<_> = (0..self.num_windows as usize).collect();
         let num_groups =
             (self.num_windows as usize) << (self.bucket_bits as usize - GROUP_SIZE_IN_BITS);
-        let mut running_sums: Vec<_> = vec![TG1Affine::ZERO; num_groups];
-        let mut sum_of_sums: Vec<_> = vec![TG1Affine::ZERO; num_groups];
+        let mut running_sums: Vec<_> = vec![TG1Affine::zero(); num_groups];
+        let mut sum_of_sums: Vec<_> = vec![TG1Affine::zero(); num_groups];
 
         // calculate running sum and sum of sum for each group
         for i in (0..GROUP_SIZE).rev() {

--- a/zkcrypto/benches/eip_4844.rs
+++ b/zkcrypto/benches/eip_4844.rs
@@ -7,11 +7,11 @@ use kzg::eip_4844::{
 use kzg_bench::benches::eip_4844::bench_eip_4844;
 use rust_kzg_zkcrypto::eip_4844::load_trusted_setup_filename_rust;
 use rust_kzg_zkcrypto::kzg_proofs::{FFTSettings, KZGSettings};
-use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1, ZG2};
+use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1, ZG2};
 use rust_kzg_zkcrypto::poly::PolyData;
 
 fn bench_eip_4844_(c: &mut Criterion) {
-    bench_eip_4844::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+    bench_eip_4844::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
         c,
         &load_trusted_setup_filename_rust,
         &blob_to_kzg_commitment_rust,

--- a/zkcrypto/benches/fk_20.rs
+++ b/zkcrypto/benches/fk_20.rs
@@ -2,21 +2,35 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::fk20::{bench_fk_multi_da, bench_fk_single_da};
 use rust_kzg_zkcrypto::fk20_proofs::{KzgFK20MultiSettings, KzgFK20SingleSettings};
 use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1, ZG2};
+use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1, ZG2};
 use rust_kzg_zkcrypto::poly::PolyData;
 
 fn bench_fk_single_da_(c: &mut Criterion) {
-    bench_fk_single_da::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, KzgFK20SingleSettings>(
-        c,
-        &generate_trusted_setup,
-    )
+    bench_fk_single_da::<
+        ZFr,
+        ZG1,
+        ZG2,
+        PolyData,
+        FFTSettings,
+        KZGSettings,
+        KzgFK20SingleSettings,
+        ZFp,
+        ZG1Affine,
+    >(c, &generate_trusted_setup)
 }
 
 fn bench_fk_multi_da_(c: &mut Criterion) {
-    bench_fk_multi_da::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, KzgFK20MultiSettings>(
-        c,
-        &generate_trusted_setup,
-    )
+    bench_fk_multi_da::<
+        ZFr,
+        ZG1,
+        ZG2,
+        PolyData,
+        FFTSettings,
+        KZGSettings,
+        KzgFK20MultiSettings,
+        ZFp,
+        ZG1Affine,
+    >(c, &generate_trusted_setup)
 }
 
 criterion_group! {

--- a/zkcrypto/benches/kzg.rs
+++ b/zkcrypto/benches/kzg.rs
@@ -2,18 +2,18 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::kzg::{bench_commit_to_poly, bench_compute_proof_single};
 
 use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1, ZG2};
+use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1, ZG2};
 use rust_kzg_zkcrypto::poly::PolyData;
 
 fn bench_commit_to_poly_(c: &mut Criterion) {
-    bench_commit_to_poly::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+    bench_commit_to_poly::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
         c,
         &generate_trusted_setup,
     );
 }
 
 fn bench_compute_proof_single_(c: &mut Criterion) {
-    bench_compute_proof_single::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+    bench_compute_proof_single::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
         c,
         &generate_trusted_setup,
     );

--- a/zkcrypto/benches/lincomb.rs
+++ b/zkcrypto/benches/lincomb.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use kzg_bench::benches::lincomb::bench_g1_lincomb;
 use rust_kzg_zkcrypto::fft_g1::g1_linear_combination;
-use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1};
+use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1};
 
 fn bench_g1_lincomb_(c: &mut Criterion) {
-    bench_g1_lincomb::<ZFr, ZG1>(c, &g1_linear_combination);
+    bench_g1_lincomb::<ZFr, ZG1, ZFp, ZG1Affine>(c, &g1_linear_combination);
 }
 
 criterion_group! {

--- a/zkcrypto/bls12_381/src/g1.rs
+++ b/zkcrypto/bls12_381/src/g1.rs
@@ -26,9 +26,9 @@ use crate::Scalar;
 #[cfg_attr(docsrs, doc(cfg(feature = "groups")))]
 #[derive(Copy, Clone, Debug)]
 pub struct G1Affine {
-    pub(crate) x: Fp,
-    pub(crate) y: Fp,
-    infinity: Choice,
+    pub x: Fp,
+    pub y: Fp,
+    pub infinity: Choice,
 }
 
 impl Default for G1Affine {

--- a/zkcrypto/bls12_381/src/lib.rs
+++ b/zkcrypto/bls12_381/src/lib.rs
@@ -85,9 +85,9 @@ pub use pairings::{pairing, Bls12, Gt, MillerLoopResult};
 pub use pairings::{multi_miller_loop, G2Prepared};
 
 pub use fp::Fp;
+pub use fp12::Fp12;
 pub use fp2::Fp2;
 pub use fp6::Fp6;
-pub use fp12::Fp12;
 
 /// Use the generic_array re-exported by digest to avoid a version mismatch
 #[cfg(feature = "experimental")]

--- a/zkcrypto/src/eip_4844.rs
+++ b/zkcrypto/src/eip_4844.rs
@@ -83,6 +83,7 @@ fn kzg_settings_to_rust(c_settings: &CKZGSettings) -> Result<KZGSettings, String
         fs: fft_settings_to_rust(c_settings)?,
         secret_g1,
         secret_g2,
+        precomputation: None,
     })
 }
 

--- a/zkcrypto/src/fft_g1.rs
+++ b/zkcrypto/src/fft_g1.rs
@@ -1,13 +1,20 @@
 use crate::consts::G1_GENERATOR;
 use crate::kzg_proofs::FFTSettings;
-use crate::kzg_types::{ZFr, ZG1};
+use crate::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1};
 use crate::multiscalar_mul::msm_variable_base;
+use kzg::msm::precompute::PrecomputationTable;
 use kzg::{Fr as KzgFr, G1Mul};
 use kzg::{FFTG1, G1};
 use std::ops::MulAssign;
 
 #[warn(unused_variables)]
-pub fn g1_linear_combination(out: &mut ZG1, points: &[ZG1], scalars: &[ZFr], _len: usize) {
+pub fn g1_linear_combination(
+    out: &mut ZG1,
+    points: &[ZG1],
+    scalars: &[ZFr],
+    _len: usize,
+    _precomputation: Option<&PrecomputationTable<ZFr, ZG1, ZFp, ZG1Affine>>,
+) {
     let g1 = msm_variable_base(points, scalars);
     out.proj = g1
 }

--- a/zkcrypto/src/fk20_proofs.rs
+++ b/zkcrypto/src/fk20_proofs.rs
@@ -1,6 +1,6 @@
 use crate::consts::G1_IDENTITY;
 use crate::kzg_proofs::{FFTSettings, KZGSettings};
-use crate::kzg_types::{ZFr as BlstFr, ZG1, ZG2};
+use crate::kzg_types::{ZFp, ZFr as BlstFr, ZG1Affine, ZG1, ZG2};
 use crate::poly::PolyData;
 use kzg::common_utils::reverse_bit_order;
 use kzg::{FFTFr, FK20MultiSettings, FK20SingleSettings, Fr, G1Mul, Poly, FFTG1, G1};
@@ -24,7 +24,7 @@ pub struct KzgFK20MultiSettings {
     pub length: usize,
 }
 
-impl FK20SingleSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings>
+impl FK20SingleSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings, ZFp, ZG1Affine>
     for KzgFK20SingleSettings
 {
     fn new(ks: &KZGSettings, n2: usize) -> Result<Self, String> {
@@ -83,7 +83,7 @@ impl FK20SingleSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings>
     }
 }
 
-impl FK20MultiSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings>
+impl FK20MultiSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings, ZFp, ZG1Affine>
     for KzgFK20MultiSettings
 {
     fn new(ks: &KZGSettings, n2: usize, chunk_len: usize) -> Result<Self, String> {

--- a/zkcrypto/src/kzg_proofs.rs
+++ b/zkcrypto/src/kzg_proofs.rs
@@ -1,12 +1,13 @@
 #![allow(non_camel_case_types)]
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};
-use crate::kzg_types::ZFr;
+use crate::kzg_types::{ZFp, ZFr, ZG1Affine};
 use crate::kzg_types::{ZFr as BlstFr, ZG1, ZG2};
 use crate::poly::PolyData;
 use bls12_381::{
     multi_miller_loop, Fp12 as ZFp12, G1Affine, G2Affine, G2Prepared, MillerLoopResult,
 };
 use kzg::eip_4844::hash_to_bls_field;
+use kzg::msm::precompute::PrecomputationTable;
 use kzg::{Fr as FrTrait, G1Mul, G2Mul};
 use std::ops::{Add, Neg};
 
@@ -42,6 +43,7 @@ pub struct KZGSettings {
     pub fs: FFTSettings,
     pub secret_g1: Vec<ZG1>,
     pub secret_g2: Vec<ZG2>,
+    pub precomputation: Option<PrecomputationTable<ZFr, ZG1, ZFp, ZG1Affine>>,
 }
 
 pub fn generate_trusted_setup(len: usize, secret: [u8; 32usize]) -> (Vec<ZG1>, Vec<ZG2>) {

--- a/zkcrypto/tests/bls12_381.rs
+++ b/zkcrypto/tests/bls12_381.rs
@@ -4,7 +4,7 @@ mod tests {
     use kzg_bench::tests::bls12_381::*;
     use rust_kzg_zkcrypto::fft_g1::g1_linear_combination;
     use rust_kzg_zkcrypto::kzg_proofs::pairings_verify;
-    use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1, ZG2};
+    use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1, ZG2};
 
     #[test]
     pub fn log_2_byte_works_() {
@@ -94,12 +94,12 @@ mod tests {
 
     #[test]
     pub fn g1_make_linear_combination_() {
-        g1_make_linear_combination::<ZFr, ZG1>(&g1_linear_combination);
+        g1_make_linear_combination::<ZFr, ZG1, ZFp, ZG1Affine>(&g1_linear_combination);
     }
 
     #[test]
     pub fn g1_random_linear_combination_() {
-        g1_random_linear_combination::<ZFr, ZG1>(&g1_linear_combination);
+        g1_random_linear_combination::<ZFr, ZG1, ZFp, ZG1Affine>(&g1_linear_combination);
     }
 
     #[test]

--- a/zkcrypto/tests/eip_4844.rs
+++ b/zkcrypto/tests/eip_4844.rs
@@ -25,7 +25,7 @@ mod tests {
     use rust_kzg_zkcrypto::consts::SCALE2_ROOT_OF_UNITY;
     use rust_kzg_zkcrypto::eip_4844::load_trusted_setup_filename_rust;
     use rust_kzg_zkcrypto::kzg_proofs::{expand_root_of_unity, FFTSettings, KZGSettings};
-    use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1, ZG2};
+    use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1, ZG2};
     use rust_kzg_zkcrypto::poly::PolyData;
 
     #[test]
@@ -40,7 +40,16 @@ mod tests {
 
     #[test]
     pub fn blob_to_kzg_commitment_test_() {
-        blob_to_kzg_commitment_test::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        blob_to_kzg_commitment_test::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
         );
@@ -48,7 +57,7 @@ mod tests {
 
     #[test]
     pub fn compute_kzg_proof_test_() {
-        compute_kzg_proof_test::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        compute_kzg_proof_test::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
             &load_trusted_setup_filename_rust,
             &compute_kzg_proof_rust,
             &blob_to_polynomial,
@@ -65,6 +74,8 @@ mod tests {
             PolyData,
             FFTSettings,
             KZGSettings,
+            ZFp,
+            ZG1Affine,
         >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
@@ -86,6 +97,8 @@ mod tests {
             PolyData,
             FFTSettings,
             KZGSettings,
+            ZFp,
+            ZG1Affine,
         >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
@@ -106,6 +119,8 @@ mod tests {
             PolyData,
             FFTSettings,
             KZGSettings,
+            ZFp,
+            ZG1Affine,
         >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
@@ -119,7 +134,16 @@ mod tests {
 
     #[test]
     pub fn compute_and_verify_blob_kzg_proof_test_() {
-        compute_and_verify_blob_kzg_proof_test::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        compute_and_verify_blob_kzg_proof_test::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
             &bytes_to_blob,
@@ -137,6 +161,8 @@ mod tests {
             PolyData,
             FFTSettings,
             KZGSettings,
+            ZFp,
+            ZG1Affine,
         >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
@@ -148,7 +174,16 @@ mod tests {
 
     #[test]
     pub fn verify_kzg_proof_batch_test_() {
-        verify_kzg_proof_batch_test::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        verify_kzg_proof_batch_test::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
             &bytes_to_blob,
@@ -166,6 +201,8 @@ mod tests {
             PolyData,
             FFTSettings,
             KZGSettings,
+            ZFp,
+            ZG1Affine,
         >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
@@ -178,7 +215,16 @@ mod tests {
     #[cfg(not(feature = "minimal-spec"))]
     #[test]
     pub fn test_vectors_blob_to_kzg_commitment_() {
-        test_vectors_blob_to_kzg_commitment::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        test_vectors_blob_to_kzg_commitment::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &blob_to_kzg_commitment_rust,
             &bytes_to_blob,
@@ -188,7 +234,16 @@ mod tests {
     #[cfg(not(feature = "minimal-spec"))]
     #[test]
     pub fn test_vectors_compute_kzg_proof_() {
-        test_vectors_compute_kzg_proof::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        test_vectors_compute_kzg_proof::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &compute_kzg_proof_rust,
             &bytes_to_blob,
@@ -198,7 +253,16 @@ mod tests {
     #[cfg(not(feature = "minimal-spec"))]
     #[test]
     pub fn test_vectors_compute_blob_kzg_proof_() {
-        test_vectors_compute_blob_kzg_proof::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        test_vectors_compute_blob_kzg_proof::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &bytes_to_blob,
             &compute_blob_kzg_proof_rust,
@@ -208,16 +272,31 @@ mod tests {
     #[cfg(not(feature = "minimal-spec"))]
     #[test]
     pub fn test_vectors_verify_kzg_proof_() {
-        test_vectors_verify_kzg_proof::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
-            &load_trusted_setup_filename_rust,
-            &verify_kzg_proof_rust,
-        );
+        test_vectors_verify_kzg_proof::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(&load_trusted_setup_filename_rust, &verify_kzg_proof_rust);
     }
 
     #[cfg(not(feature = "minimal-spec"))]
     #[test]
     pub fn test_vectors_verify_blob_kzg_proof_() {
-        test_vectors_verify_blob_kzg_proof::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        test_vectors_verify_blob_kzg_proof::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &bytes_to_blob,
             &verify_blob_kzg_proof_rust,
@@ -226,7 +305,16 @@ mod tests {
     #[cfg(not(feature = "minimal-spec"))]
     #[test]
     pub fn test_vectors_verify_blob_kzg_proof_batch_() {
-        test_vectors_verify_blob_kzg_proof_batch::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        test_vectors_verify_blob_kzg_proof_batch::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(
             &load_trusted_setup_filename_rust,
             &bytes_to_blob,
             &verify_blob_kzg_proof_batch_rust,

--- a/zkcrypto/tests/fk20_proofs.rs
+++ b/zkcrypto/tests/fk20_proofs.rs
@@ -4,15 +4,23 @@ mod tests {
 
     use rust_kzg_zkcrypto::fk20_proofs::{KzgFK20MultiSettings, KzgFK20SingleSettings};
     use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-    use rust_kzg_zkcrypto::kzg_types::ZFr as BlstFr;
+    use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr as BlstFr, ZG1Affine};
     use rust_kzg_zkcrypto::kzg_types::{ZG1, ZG2};
     use rust_kzg_zkcrypto::poly::PolyData;
 
     #[test]
     fn test_fk_single() {
-        fk_single::<BlstFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, KzgFK20SingleSettings>(
-            &generate_trusted_setup,
-        );
+        fk_single::<
+            BlstFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            KzgFK20SingleSettings,
+            ZFp,
+            ZG1Affine,
+        >(&generate_trusted_setup);
     }
 
     #[test]
@@ -25,6 +33,8 @@ mod tests {
             FFTSettings,
             KZGSettings,
             KzgFK20SingleSettings,
+            ZFp,
+            ZG1Affine,
         >(&generate_trusted_setup);
     }
 
@@ -38,6 +48,8 @@ mod tests {
             FFTSettings,
             KZGSettings,
             KzgFK20MultiSettings,
+            ZFp,
+            ZG1Affine,
         >(&generate_trusted_setup);
     }
 
@@ -51,6 +63,8 @@ mod tests {
             FFTSettings,
             KZGSettings,
             KzgFK20MultiSettings,
+            ZFp,
+            ZG1Affine,
         >(&generate_trusted_setup);
     }
 
@@ -64,6 +78,8 @@ mod tests {
             FFTSettings,
             KZGSettings,
             KzgFK20MultiSettings,
+            ZFp,
+            ZG1Affine,
         >(&generate_trusted_setup);
     }
 
@@ -77,6 +93,8 @@ mod tests {
             FFTSettings,
             KZGSettings,
             KzgFK20MultiSettings,
+            ZFp,
+            ZG1Affine,
         >(&generate_trusted_setup);
     }
 }

--- a/zkcrypto/tests/kzg_proofs.rs
+++ b/zkcrypto/tests/kzg_proofs.rs
@@ -4,28 +4,39 @@ mod tests {
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
     };
     use rust_kzg_zkcrypto::kzg_proofs::{generate_trusted_setup, FFTSettings, KZGSettings};
-    use rust_kzg_zkcrypto::kzg_types::{ZFr, ZG1, ZG2};
+    use rust_kzg_zkcrypto::kzg_types::{ZFp, ZFr, ZG1Affine, ZG1, ZG2};
     use rust_kzg_zkcrypto::poly::PolyData;
 
     #[test]
     fn proof_single_() {
-        proof_single::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(&generate_trusted_setup);
+        proof_single::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
+            &generate_trusted_setup,
+        );
     }
     #[test]
     fn commit_to_nil_poly_() {
-        commit_to_nil_poly::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
+        commit_to_nil_poly::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
             &generate_trusted_setup,
         );
     }
     #[test]
     fn commit_to_too_long_poly_() {
-        commit_to_too_long_poly_returns_err::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(
-            &generate_trusted_setup,
-        );
+        commit_to_too_long_poly_returns_err::<
+            ZFr,
+            ZG1,
+            ZG2,
+            PolyData,
+            FFTSettings,
+            KZGSettings,
+            ZFp,
+            ZG1Affine,
+        >(&generate_trusted_setup);
     }
 
     #[test]
     fn proof_multi_() {
-        proof_multi::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings>(&generate_trusted_setup);
+        proof_multi::<ZFr, ZG1, ZG2, PolyData, FFTSettings, KZGSettings, ZFp, ZG1Affine>(
+            &generate_trusted_setup,
+        );
     }
 }


### PR DESCRIPTION
implements missing traits so that zkcrypto backend compiles

not compatible with kzg generic msm