### PR TITLE
fix constantine dep install on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Install constantine backend deps
       - name: "constantine - install deps"
-        if: matrix.backend == 'constantine' && matrix.os == 'ubuntu-latest'
+        if: matrix.backend == 'constantine'
         run: |
           sudo DEBIAN_FRONTEND='noninteractive' apt-fast install \
             --no-install-recommends -yq \


### PR DESCRIPTION
Was copy-pasting from different workflow file & forgot that we don't use 'os' matrix (releases are all built on ubuntu-latest image)