### PR TITLE
Enable BGMW by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "num_cpus",
  "rayon",
  "sha2 0.10.8",
+ "siphasher",
  "threadpool",
 ]
 
@@ -1224,7 +1225,6 @@ dependencies = [
  "once_cell",
  "rand",
  "rayon",
- "siphasher",
  "smallvec",
 ]
 

--- a/arkworks/Cargo.toml
+++ b/arkworks/Cargo.toml
@@ -25,7 +25,8 @@ rand = { version = "0.8.5" }
 [features]
 default = [
     "std",
-    "rand"
+    "rand",
+    "bgmw"
 ]
 std = [
     "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", 

--- a/arkworks/src/kzg_proofs.rs
+++ b/arkworks/src/kzg_proofs.rs
@@ -1,8 +1,11 @@
 #![allow(non_camel_case_types)]
+
+extern crate alloc;
 use super::utils::{blst_poly_into_pc_poly, PolyData};
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};
 use crate::kzg_types::{ArkFp, ArkFr, ArkG1Affine};
 use crate::kzg_types::{ArkFr as BlstFr, ArkG1, ArkG2};
+use alloc::sync::Arc;
 use ark_bls12_381::Bls12_381;
 use ark_ec::pairing::Pairing;
 use ark_ec::CurveGroup;
@@ -46,7 +49,7 @@ pub struct KZGSettings {
     pub fs: FFTSettings,
     pub secret_g1: Vec<ArkG1>,
     pub secret_g2: Vec<ArkG2>,
-    pub precomputation: Option<PrecomputationTable<ArkFr, ArkG1, ArkFp, ArkG1Affine>>,
+    pub precomputation: Option<Arc<PrecomputationTable<ArkFr, ArkG1, ArkFp, ArkG1Affine>>>,
 }
 
 pub fn generate_trusted_setup(len: usize, secret: [u8; 32usize]) -> (Vec<ArkG1>, Vec<ArkG2>) {

--- a/arkworks/src/kzg_types.rs
+++ b/arkworks/src/kzg_types.rs
@@ -34,6 +34,9 @@ use kzg::{
 };
 use std::ops::{AddAssign, Mul, Neg, Sub};
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 fn bytes_be_to_uint64(inp: &[u8]) -> u64 {
     u64::from_be_bytes(inp.try_into().expect("Input wasn't 8 elements..."))
 }
@@ -630,7 +633,7 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
             secret_g1: secret_g1.to_vec(),
             secret_g2: secret_g2.to_vec(),
             fs: fft_settings.clone(),
-            precomputation: precompute(secret_g1).ok().flatten(),
+            precomputation: precompute(secret_g1).ok().flatten().map(Arc::new),
         })
     }
 
@@ -793,7 +796,7 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
     }
 
     fn get_precomputation(&self) -> Option<&PrecomputationTable<ArkFr, ArkG1, ArkFp, ArkG1Affine>> {
-        self.precomputation.as_ref()
+        self.precomputation.as_ref().map(|v| v.as_ref())
     }
 }
 

--- a/blst/Cargo.toml
+++ b/blst/Cargo.toml
@@ -12,7 +12,6 @@ rand = { version = "0.8.5", optional = true }
 rayon = { version = "1.8.0", optional = true } 
 smallvec = { version = "1.11.1", features = ["const_generics"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-siphasher = { version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -23,6 +22,7 @@ rand = "0.8.5"
 default = [
     "std",
     "rand",
+    "bgmw"
 ]
 std = [
     "hex/std",

--- a/constantine/Cargo.toml
+++ b/constantine/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8.5"
 default = [
     "std",
     "rand",
+    "bgmw"
 ]
 std = [
     "hex/std",

--- a/constantine/src/eip_4844.rs
+++ b/constantine/src/eip_4844.rs
@@ -22,14 +22,16 @@ use std::io::Read;
 use kzg::eip_4844::load_trusted_setup_string;
 
 use kzg::eip_4844::{
-    Blob, Bytes32, Bytes48, CKZGSettings, KZGCommitment, KZGProof, BYTES_PER_FIELD_ELEMENT,
-    BYTES_PER_G1, BYTES_PER_G2, C_KZG_RET, C_KZG_RET_BADARGS, C_KZG_RET_OK,
-    FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS, TRUSTED_SETUP_NUM_G2_POINTS,
+    Blob, Bytes32, Bytes48, CKZGSettings, KZGCommitment, KZGProof, PrecomputationTableManager,
+    BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1, BYTES_PER_G2, C_KZG_RET, C_KZG_RET_BADARGS,
+    C_KZG_RET_OK, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
+    TRUSTED_SETUP_NUM_G2_POINTS,
 };
 
 use crate::types::fft_settings::CtFFTSettings;
+use crate::types::fp::CtFp;
 use crate::types::fr::CtFr;
-use crate::types::g1::CtG1;
+use crate::types::g1::{CtG1, CtG1Affine};
 
 use crate::types::g2::CtG2;
 use crate::types::kzg_settings::CtKZGSettings;

--- a/constantine/src/eip_4844.rs
+++ b/constantine/src/eip_4844.rs
@@ -37,6 +37,9 @@ use crate::types::kzg_settings::CtKZGSettings;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+static mut PRECOMPUTATION_TABLES: PrecomputationTableManager<CtFr, CtG1, CtFp, CtG1Affine> =
+    PrecomputationTableManager::new();
+
 #[cfg(feature = "std")]
 pub fn load_trusted_setup_filename_rust(filepath: &str) -> Result<CtKZGSettings, String> {
     let mut file = File::open(filepath).map_err(|_| "Unable to open file".to_string())?;
@@ -186,9 +189,14 @@ pub unsafe extern "C" fn load_trusted_setup(
     let g1_bytes = core::slice::from_raw_parts(g1_bytes, n1 * BYTES_PER_G1);
     let g2_bytes = core::slice::from_raw_parts(g2_bytes, n2 * BYTES_PER_G2);
     TRUSTED_SETUP_NUM_G1_POINTS = g1_bytes.len() / BYTES_PER_G1;
-    let settings = handle_ckzg_badargs!(load_trusted_setup_rust(g1_bytes, g2_bytes));
+    let mut settings = handle_ckzg_badargs!(load_trusted_setup_rust(g1_bytes, g2_bytes));
 
-    *out = kzg_settings_to_c(&settings);
+    let c_settings = kzg_settings_to_c(&settings);
+
+    PRECOMPUTATION_TABLES.save_precomputation(settings.precomputation.take(), &c_settings);
+
+    *out = c_settings;
+
     C_KZG_RET_OK
 }
 
@@ -210,12 +218,17 @@ pub unsafe extern "C" fn load_trusted_setup_file(
         // deallocate its KZGSettings pointer when no exception is thrown).
         return C_KZG_RET_BADARGS;
     }
-    let settings = handle_ckzg_badargs!(load_trusted_setup_rust(
+    let mut settings = handle_ckzg_badargs!(load_trusted_setup_rust(
         g1_bytes.as_slice(),
         g2_bytes.as_slice()
     ));
 
-    *out = kzg_settings_to_c(&settings);
+    let c_settings = kzg_settings_to_c(&settings);
+
+    PRECOMPUTATION_TABLES.save_precomputation(settings.precomputation.take(), &c_settings);
+
+    *out = c_settings;
+
     C_KZG_RET_OK
 }
 
@@ -250,6 +263,8 @@ pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
     if s.is_null() {
         return;
     }
+
+    PRECOMPUTATION_TABLES.remove_precomputation(&*s);
 
     let max_width = (*s).max_width as usize;
     let roots = Box::from_raw(core::slice::from_raw_parts_mut(

--- a/constantine/src/types/kzg_settings.rs
+++ b/constantine/src/types/kzg_settings.rs
@@ -203,6 +203,6 @@ impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine> for 
     }
 
     fn get_precomputation(&self) -> Option<&PrecomputationTable<CtFr, CtG1, CtFp, CtG1Affine>> {
-        self.precomputation.as_ref()
+        self.precomputation.as_ref().map(|v| v.as_ref())
     }
 }

--- a/constantine/src/types/kzg_settings.rs
+++ b/constantine/src/types/kzg_settings.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use kzg::msm::precompute::{precompute, PrecomputationTable};
@@ -22,7 +23,7 @@ pub struct CtKZGSettings {
     pub fs: CtFFTSettings,
     pub secret_g1: Vec<CtG1>,
     pub secret_g2: Vec<CtG2>,
-    pub precomputation: Option<PrecomputationTable<CtFr, CtG1, CtFp, CtG1Affine>>,
+    pub precomputation: Option<Arc<PrecomputationTable<CtFr, CtG1, CtFp, CtG1Affine>>>,
 }
 
 impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine> for CtKZGSettings {
@@ -36,7 +37,7 @@ impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine> for 
             secret_g1: secret_g1.to_vec(),
             secret_g2: secret_g2.to_vec(),
             fs: fft_settings.clone(),
-            precomputation: precompute(secret_g1).ok().flatten(),
+            precomputation: precompute(secret_g1).ok().flatten().map(Arc::new),
         })
     }
 

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -9,6 +9,7 @@ sha2 = { version = "0.10.6", default-features = false }
 num_cpus = { version = "1.16.0", optional = true }
 rayon = { version = "1.8.0", optional = true } 
 threadpool = { version = "^1.8.1", optional = true }
+siphasher = { version = "1.0.0", default-features = false }
 
 [features]
 default = [
@@ -22,7 +23,8 @@ parallel = [
     "dep:threadpool"
 ]
 std = [
-    "sha2/std"
+    "sha2/std",
+    "siphasher/std"
 ]
 rand = []
 arkmsm = []

--- a/kzg/src/msm/bgmw.rs
+++ b/kzg/src/msm/bgmw.rs
@@ -298,7 +298,15 @@ impl<
         }
 
         #[cfg(not(feature = "parallel"))]
-        pippenger_window_size(npoints)
+        {
+            let n_exponent = npoints.trailing_zeros();
+
+            // TODO: experiment with different q exponents, to find optimal
+            match n_exponent {
+                12 => 13, // this value is picked from https://github.com/LuoGuiwen/MSM_blst/blob/2e098f09f07969ac3191406976be6d1c197100f2/ches_config_files/config_file_n_exp_12.h#L17
+                _ => pippenger_window_size(npoints), // default to pippenger window size. This is not optimal window size, but still better than simple pippenger
+            }
+        }
     }
 }
 


### PR DESCRIPTION
In this PR:
* `bgmw` feature enabled for blst, arkworks, and constantine backends.
* Picked better window size for `BGMW` when point count = `4096` (trusted setup size)