### PR TITLE
Bump C_KZG_4844_GIT_HASH

### DIFF
--- a/.github/workflows/backend-benchmarks.yml
+++ b/.github/workflows/backend-benchmarks.yml
@@ -33,7 +33,8 @@ jobs:
           distribution: "temurin"
           java-version: "11"
 
-      - uses: jiro4989/setup-nim-action@v1
+      - if: matrix.backend == 'constantine'
+        uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: '1.6.14'
 

--- a/.github/workflows/backend-benchmarks.yml
+++ b/.github/workflows/backend-benchmarks.yml
@@ -33,8 +33,7 @@ jobs:
           distribution: "temurin"
           java-version: "11"
 
-      - if: matrix.backend == 'constantine'
-        uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: '1.6.14'
 

--- a/.github/workflows/backend-benchmarks.yml
+++ b/.github/workflows/backend-benchmarks.yml
@@ -1,7 +1,7 @@
 name: benchmarks
 on: [push, pull_request, workflow_dispatch]
 env:
-  C_KZG_4844_GIT_HASH: '624aa60d01da524827123506975431aa5454c80d'
+  C_KZG_4844_GIT_HASH: '5115420ba3f919f5501155ba18633667001b6a07'
 
 jobs:
   benchmarks:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: jiro4989/setup-nim-action@v1
         with:
-          nim-version: '1.6.14'
+          nim-version: '2.0.2'
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -48,8 +48,7 @@ jobs:
           distribution: "temurin"
           java-version: "11"
 
-      - if: matrix.backend == 'constantine'
-        uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: '1.6.14'
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,7 +1,7 @@
 name: tests
 on: [push, pull_request, workflow_dispatch]
 env:
-  C_KZG_4844_GIT_HASH: '624aa60d01da524827123506975431aa5454c80d'
+  C_KZG_4844_GIT_HASH: '5115420ba3f919f5501155ba18633667001b6a07'
 
 jobs:
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  C_KZG_4844_GIT_HASH: '624aa60d01da524827123506975431aa5454c80d'
+  C_KZG_4844_GIT_HASH: '5115420ba3f919f5501155ba18633667001b6a07'
 
 jobs:
   release-build:

--- a/arkworks/nim.patch
+++ b/arkworks/nim.patch
@@ -1,0 +1,35 @@
+From f34d21606bb5bc3dee4e7a643d7ab89a2c994fef Mon Sep 17 00:00:00 2001
+From: sirse <artiom.tretjakovas2@gmail.com>
+Date: Thu, 25 Jan 2024 11:26:35 +0200
+Subject: [PATCH] Patch nim bindings
+
+---
+ bindings/nim/kzg_abi.nim | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/nim/kzg_abi.nim b/bindings/nim/kzg_abi.nim
+index 36e4ba1..74d0ebc 100644
+--- a/bindings/nim/kzg_abi.nim
++++ b/bindings/nim/kzg_abi.nim
+@@ -10,6 +10,7 @@ from os import DirSep, AltSep
+ const
+   # kzgPath: c-kzg-4844 project path, removing 3 last elem
+   kzgPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/"
++  rustKzgPath = currentSourcePath.rsplit({DirSep, AltSep}, 5)[0] & "/"
+   blstPath = kzgPath & "blst/"
+   srcPath  = kzgPath & "src/"
+   bindingsPath = blstPath & "bindings"
+@@ -20,7 +21,9 @@ when not defined(kzgExternalBlst):
+   {.compile: blstPath & "src/server.c"}
+   {.passc: "-D__BLST_PORTABLE__"}
+ 
+-{.compile: srcPath & "c_kzg_4844.c"}
++{.passl: "-L" & rustKzgPath & "target/release" .}
++{.passl: "-l:rust_kzg_arkworks.a" .}
++{.passl: "-lm" .}
+ 
+ {.passc: "-I" & bindingsPath .}
+ {.passc: "-I" & srcPath .}
+-- 
+2.34.1
+

--- a/arkworks/rust.patch
+++ b/arkworks/rust.patch
@@ -1,15 +1,15 @@
-From c3d4cb77f5a797bd8f454a0d88e034391514ebd7 Mon Sep 17 00:00:00 2001
+From e7d529a9ba017de920555ae9b4ab05a18174cdcf Mon Sep 17 00:00:00 2001
 From: sirse <artiom.tretjakovas2@gmail.com>
-Date: Thu, 26 Oct 2023 13:46:19 +0300
-Subject: [PATCH] Patch rust binding
+Date: Thu, 25 Jan 2024 11:42:12 +0200
+Subject: [PATCH] Patch rust bindings
 
 ---
  bindings/rust/Cargo.toml |  1 +
- bindings/rust/build.rs   | 29 +++++------------------------
- 2 files changed, 6 insertions(+), 24 deletions(-)
+ bindings/rust/build.rs   | 22 +++-------------------
+ 2 files changed, 4 insertions(+), 19 deletions(-)
 
 diff --git a/bindings/rust/Cargo.toml b/bindings/rust/Cargo.toml
-index ab1f5b8..44e410e 100644
+index 98bd814..9391f27 100644
 --- a/bindings/rust/Cargo.toml
 +++ b/bindings/rust/Cargo.toml
 @@ -1,3 +1,4 @@
@@ -18,7 +18,7 @@ index ab1f5b8..44e410e 100644
  name = "c-kzg"
  version = "0.1.0"
 diff --git a/bindings/rust/build.rs b/bindings/rust/build.rs
-index 692305a..e874ccd 100644
+index 5148333..ec42e21 100644
 --- a/bindings/rust/build.rs
 +++ b/bindings/rust/build.rs
 @@ -15,24 +15,7 @@ fn main() {
@@ -27,7 +27,7 @@ index 692305a..e874ccd 100644
  
 -    let mut cc = cc::Build::new();
 -
--    #[cfg(windows)]
+-    #[cfg(all(windows, target_env = "msvc"))]
 -    {
 -        cc.flag("-D_CRT_SECURE_NO_WARNINGS");
 -
@@ -47,7 +47,7 @@ index 692305a..e874ccd 100644
  
      let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
      let bindings_out_path = out_dir.join("generated.rs");
-@@ -46,14 +29,12 @@ fn main() {
+@@ -46,7 +29,8 @@ fn main() {
      );
  
      // Finally, tell cargo this provides ckzg/ckzg_min
@@ -56,16 +56,7 @@ index 692305a..e874ccd 100644
 +    println!("cargo:rustc-link-arg=-l:rust_kzg_arkworks.a");
  }
  
--fn make_bindings<P>(
--    header_path: &str,
--    blst_headers_dir: &str,
--    bindings_out_path: P,
--) where
-+fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
-+where
-     P: AsRef<std::path::Path>,
- {
-     use bindgen::Builder;
+ fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
 -- 
 2.34.1
 

--- a/blst/nim.patch
+++ b/blst/nim.patch
@@ -1,0 +1,35 @@
+From f34d21606bb5bc3dee4e7a643d7ab89a2c994fef Mon Sep 17 00:00:00 2001
+From: sirse <artiom.tretjakovas2@gmail.com>
+Date: Thu, 25 Jan 2024 11:26:35 +0200
+Subject: [PATCH] Patch nim bindings
+
+---
+ bindings/nim/kzg_abi.nim | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/nim/kzg_abi.nim b/bindings/nim/kzg_abi.nim
+index 36e4ba1..74d0ebc 100644
+--- a/bindings/nim/kzg_abi.nim
++++ b/bindings/nim/kzg_abi.nim
+@@ -10,6 +10,7 @@ from os import DirSep, AltSep
+ const
+   # kzgPath: c-kzg-4844 project path, removing 3 last elem
+   kzgPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/"
++  rustKzgPath = currentSourcePath.rsplit({DirSep, AltSep}, 5)[0] & "/"
+   blstPath = kzgPath & "blst/"
+   srcPath  = kzgPath & "src/"
+   bindingsPath = blstPath & "bindings"
+@@ -20,7 +21,9 @@ when not defined(kzgExternalBlst):
+   {.compile: blstPath & "src/server.c"}
+   {.passc: "-D__BLST_PORTABLE__"}
+ 
+-{.compile: srcPath & "c_kzg_4844.c"}
++{.passl: "-L" & rustKzgPath & "target/release" .}
++{.passl: "-l:rust_kzg_blst.a" .}
++{.passl: "-lm" .}
+ 
+ {.passc: "-I" & bindingsPath .}
+ {.passc: "-I" & srcPath .}
+-- 
+2.34.1
+

--- a/blst/rust.patch
+++ b/blst/rust.patch
@@ -1,15 +1,15 @@
-From c3d4cb77f5a797bd8f454a0d88e034391514ebd7 Mon Sep 17 00:00:00 2001
+From e7d529a9ba017de920555ae9b4ab05a18174cdcf Mon Sep 17 00:00:00 2001
 From: sirse <artiom.tretjakovas2@gmail.com>
-Date: Thu, 26 Oct 2023 13:46:19 +0300
-Subject: [PATCH] Patch rust binding
+Date: Thu, 25 Jan 2024 11:42:12 +0200
+Subject: [PATCH] Patch rust bindings
 
 ---
  bindings/rust/Cargo.toml |  1 +
- bindings/rust/build.rs   | 29 +++++------------------------
- 2 files changed, 6 insertions(+), 24 deletions(-)
+ bindings/rust/build.rs   | 22 +++-------------------
+ 2 files changed, 4 insertions(+), 19 deletions(-)
 
 diff --git a/bindings/rust/Cargo.toml b/bindings/rust/Cargo.toml
-index ab1f5b8..44e410e 100644
+index 98bd814..9391f27 100644
 --- a/bindings/rust/Cargo.toml
 +++ b/bindings/rust/Cargo.toml
 @@ -1,3 +1,4 @@
@@ -18,7 +18,7 @@ index ab1f5b8..44e410e 100644
  name = "c-kzg"
  version = "0.1.0"
 diff --git a/bindings/rust/build.rs b/bindings/rust/build.rs
-index 692305a..e874ccd 100644
+index 5148333..ec42e21 100644
 --- a/bindings/rust/build.rs
 +++ b/bindings/rust/build.rs
 @@ -15,24 +15,7 @@ fn main() {
@@ -27,7 +27,7 @@ index 692305a..e874ccd 100644
  
 -    let mut cc = cc::Build::new();
 -
--    #[cfg(windows)]
+-    #[cfg(all(windows, target_env = "msvc"))]
 -    {
 -        cc.flag("-D_CRT_SECURE_NO_WARNINGS");
 -
@@ -47,7 +47,7 @@ index 692305a..e874ccd 100644
  
      let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
      let bindings_out_path = out_dir.join("generated.rs");
-@@ -46,14 +29,12 @@ fn main() {
+@@ -46,7 +29,8 @@ fn main() {
      );
  
      // Finally, tell cargo this provides ckzg/ckzg_min
@@ -56,16 +56,7 @@ index 692305a..e874ccd 100644
 +    println!("cargo:rustc-link-arg=-l:rust_kzg_blst.a");
  }
  
--fn make_bindings<P>(
--    header_path: &str,
--    blst_headers_dir: &str,
--    bindings_out_path: P,
--) where
-+fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
-+where
-     P: AsRef<std::path::Path>,
- {
-     use bindgen::Builder;
+ fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
 -- 
 2.34.1
 

--- a/constantine/nim.patch
+++ b/constantine/nim.patch
@@ -1,0 +1,35 @@
+From f34d21606bb5bc3dee4e7a643d7ab89a2c994fef Mon Sep 17 00:00:00 2001
+From: sirse <artiom.tretjakovas2@gmail.com>
+Date: Thu, 25 Jan 2024 11:26:35 +0200
+Subject: [PATCH] Patch nim bindings
+
+---
+ bindings/nim/kzg_abi.nim | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/nim/kzg_abi.nim b/bindings/nim/kzg_abi.nim
+index 36e4ba1..74d0ebc 100644
+--- a/bindings/nim/kzg_abi.nim
++++ b/bindings/nim/kzg_abi.nim
+@@ -10,6 +10,7 @@ from os import DirSep, AltSep
+ const
+   # kzgPath: c-kzg-4844 project path, removing 3 last elem
+   kzgPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/"
++  rustKzgPath = currentSourcePath.rsplit({DirSep, AltSep}, 5)[0] & "/"
+   blstPath = kzgPath & "blst/"
+   srcPath  = kzgPath & "src/"
+   bindingsPath = blstPath & "bindings"
+@@ -20,7 +21,9 @@ when not defined(kzgExternalBlst):
+   {.compile: blstPath & "src/server.c"}
+   {.passc: "-D__BLST_PORTABLE__"}
+ 
+-{.compile: srcPath & "c_kzg_4844.c"}
++{.passl: "-L" & rustKzgPath & "target/release" .}
++{.passl: "-l:rust_kzg_constantine.a" .}
++{.passl: "-lm" .}
+ 
+ {.passc: "-I" & bindingsPath .}
+ {.passc: "-I" & srcPath .}
+-- 
+2.34.1
+

--- a/constantine/rust.patch
+++ b/constantine/rust.patch
@@ -1,15 +1,15 @@
-From c3d4cb77f5a797bd8f454a0d88e034391514ebd7 Mon Sep 17 00:00:00 2001
+From e7d529a9ba017de920555ae9b4ab05a18174cdcf Mon Sep 17 00:00:00 2001
 From: sirse <artiom.tretjakovas2@gmail.com>
-Date: Thu, 26 Oct 2023 13:46:19 +0300
-Subject: [PATCH] Patch rust binding
+Date: Thu, 25 Jan 2024 11:42:12 +0200
+Subject: [PATCH] Patch rust bindings
 
 ---
  bindings/rust/Cargo.toml |  1 +
- bindings/rust/build.rs   | 29 +++++------------------------
- 2 files changed, 6 insertions(+), 24 deletions(-)
+ bindings/rust/build.rs   | 22 +++-------------------
+ 2 files changed, 4 insertions(+), 19 deletions(-)
 
 diff --git a/bindings/rust/Cargo.toml b/bindings/rust/Cargo.toml
-index ab1f5b8..44e410e 100644
+index 98bd814..9391f27 100644
 --- a/bindings/rust/Cargo.toml
 +++ b/bindings/rust/Cargo.toml
 @@ -1,3 +1,4 @@
@@ -18,7 +18,7 @@ index ab1f5b8..44e410e 100644
  name = "c-kzg"
  version = "0.1.0"
 diff --git a/bindings/rust/build.rs b/bindings/rust/build.rs
-index 692305a..e874ccd 100644
+index 5148333..ec42e21 100644
 --- a/bindings/rust/build.rs
 +++ b/bindings/rust/build.rs
 @@ -15,24 +15,7 @@ fn main() {
@@ -27,7 +27,7 @@ index 692305a..e874ccd 100644
  
 -    let mut cc = cc::Build::new();
 -
--    #[cfg(windows)]
+-    #[cfg(all(windows, target_env = "msvc"))]
 -    {
 -        cc.flag("-D_CRT_SECURE_NO_WARNINGS");
 -
@@ -47,7 +47,7 @@ index 692305a..e874ccd 100644
  
      let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
      let bindings_out_path = out_dir.join("generated.rs");
-@@ -46,14 +29,12 @@ fn main() {
+@@ -46,7 +29,8 @@ fn main() {
      );
  
      // Finally, tell cargo this provides ckzg/ckzg_min
@@ -56,16 +56,7 @@ index 692305a..e874ccd 100644
 +    println!("cargo:rustc-link-arg=-l:rust_kzg_constantine.a");
  }
  
--fn make_bindings<P>(
--    header_path: &str,
--    blst_headers_dir: &str,
--    bindings_out_path: P,
--) where
-+fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
-+where
-     P: AsRef<std::path::Path>,
- {
-     use bindgen::Builder;
+ fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
 -- 
 2.34.1
 

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -154,18 +154,22 @@ cd ../..
 
 ###################### nim tests ######################
 
-print_msg "Patching nim binding"
-git apply < ../nim.patch
+if [ "$backend" != "constantine" ]; then
+  print_msg "Patching nim binding"
+  git apply < ../nim.patch
 
-print_msg "Installing nim dependencies"
-nimble install -y stew
-nimble install -y unittest2
-nimble install -y yaml
+  print_msg "Installing nim dependencies"
+  nimble install -y stew
+  nimble install -y unittest2
+  nimble install -y yaml
 
-print_msg "Running nim tests"
-cd bindings/nim || exit
-nim test
-cd ../../..
+  print_msg "Running nim tests"
+  cd bindings/nim || exit
+  nim test
+  cd ../../..
+else
+  print_msg "Currently, nim bindings are not supported for constantine backend"
+fi
 
 ###################### cleaning up ######################
 

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -161,6 +161,7 @@ print_msg "Installing nim dependencies"
 nimble install -y stew
 nimble install -y unittest2
 nimble install -y yaml
+nimble install -y nim
 
 print_msg "Running nim tests"
 cd bindings/nim || exit

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -158,11 +158,14 @@ print_msg "Patching nim binding"
 git apply < ../nim.patch
 
 print_msg "Installing nim dependencies"
-nimble install --depsOnly -y
+nimble install -y stew
+nimble install -y unittest2
+nimble install -y yaml
 
 print_msg "Running nim tests"
-nimble test -y
-cd ..
+cd bindings/nim || exit
+nim test
+cd ../../..
 
 ###################### cleaning up ######################
 

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -161,7 +161,6 @@ print_msg "Installing nim dependencies"
 nimble install -y stew
 nimble install -y unittest2
 nimble install -y yaml
-nimble install -y nim
 
 print_msg "Running nim tests"
 cd bindings/nim || exit

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -1,4 +1,4 @@
-#!/opt/homebrew/bin/bash
+#!/bin/bash
 
 set -e
 
@@ -43,6 +43,7 @@ else
   cargo rustc --release --crate-type=staticlib
 fi
 
+rm -f ../target/release/rust_kzg_$backend.a
 mv ../target/release/librust_kzg_$backend.a ../target/release/rust_kzg_$backend.a
 
 ###################### cloning c-kzg-4844 ######################
@@ -149,6 +150,14 @@ cd bindings/go || exit
 
 print_msg "Running go tests"
 CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test
+cd ../..
+
+###################### nim tests ######################
+
+print_msg "Patching nim binding"
+git apply < ../nim.patch
+cd bindings/nim || exit
+nim test
 cd ../../..
 
 ###################### cleaning up ######################

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -156,9 +156,8 @@ cd ../..
 
 print_msg "Patching nim binding"
 git apply < ../nim.patch
-cd bindings/nim || exit
-nim test
-cd ../../..
+nimble test -y
+cd ..
 
 ###################### cleaning up ######################
 

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -156,6 +156,11 @@ cd ../..
 
 print_msg "Patching nim binding"
 git apply < ../nim.patch
+
+print_msg "Installing nim dependencies"
+nimble install --depsOnly
+
+print_msg "Running nim tests"
 nimble test -y
 cd ..
 

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -158,7 +158,7 @@ print_msg "Patching nim binding"
 git apply < ../nim.patch
 
 print_msg "Installing nim dependencies"
-nimble install --depsOnly
+nimble install --depsOnly -y
 
 print_msg "Running nim tests"
 nimble test -y

--- a/zkcrypto/nim.patch
+++ b/zkcrypto/nim.patch
@@ -1,0 +1,35 @@
+From f34d21606bb5bc3dee4e7a643d7ab89a2c994fef Mon Sep 17 00:00:00 2001
+From: sirse <artiom.tretjakovas2@gmail.com>
+Date: Thu, 25 Jan 2024 11:26:35 +0200
+Subject: [PATCH] Patch nim bindings
+
+---
+ bindings/nim/kzg_abi.nim | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/nim/kzg_abi.nim b/bindings/nim/kzg_abi.nim
+index 36e4ba1..74d0ebc 100644
+--- a/bindings/nim/kzg_abi.nim
++++ b/bindings/nim/kzg_abi.nim
+@@ -10,6 +10,7 @@ from os import DirSep, AltSep
+ const
+   # kzgPath: c-kzg-4844 project path, removing 3 last elem
+   kzgPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/"
++  rustKzgPath = currentSourcePath.rsplit({DirSep, AltSep}, 5)[0] & "/"
+   blstPath = kzgPath & "blst/"
+   srcPath  = kzgPath & "src/"
+   bindingsPath = blstPath & "bindings"
+@@ -20,7 +21,9 @@ when not defined(kzgExternalBlst):
+   {.compile: blstPath & "src/server.c"}
+   {.passc: "-D__BLST_PORTABLE__"}
+ 
+-{.compile: srcPath & "c_kzg_4844.c"}
++{.passl: "-L" & rustKzgPath & "target/release" .}
++{.passl: "-l:rust_kzg_zkcrypto.a" .}
++{.passl: "-lm" .}
+ 
+ {.passc: "-I" & bindingsPath .}
+ {.passc: "-I" & srcPath .}
+-- 
+2.34.1
+

--- a/zkcrypto/rust.patch
+++ b/zkcrypto/rust.patch
@@ -1,15 +1,15 @@
-From c3d4cb77f5a797bd8f454a0d88e034391514ebd7 Mon Sep 17 00:00:00 2001
+From e7d529a9ba017de920555ae9b4ab05a18174cdcf Mon Sep 17 00:00:00 2001
 From: sirse <artiom.tretjakovas2@gmail.com>
-Date: Thu, 26 Oct 2023 13:46:19 +0300
-Subject: [PATCH] Patch rust binding
+Date: Thu, 25 Jan 2024 11:42:12 +0200
+Subject: [PATCH] Patch rust bindings
 
 ---
  bindings/rust/Cargo.toml |  1 +
- bindings/rust/build.rs   | 29 +++++------------------------
- 2 files changed, 6 insertions(+), 24 deletions(-)
+ bindings/rust/build.rs   | 22 +++-------------------
+ 2 files changed, 4 insertions(+), 19 deletions(-)
 
 diff --git a/bindings/rust/Cargo.toml b/bindings/rust/Cargo.toml
-index ab1f5b8..44e410e 100644
+index 98bd814..9391f27 100644
 --- a/bindings/rust/Cargo.toml
 +++ b/bindings/rust/Cargo.toml
 @@ -1,3 +1,4 @@
@@ -18,7 +18,7 @@ index ab1f5b8..44e410e 100644
  name = "c-kzg"
  version = "0.1.0"
 diff --git a/bindings/rust/build.rs b/bindings/rust/build.rs
-index 692305a..e874ccd 100644
+index 5148333..ec42e21 100644
 --- a/bindings/rust/build.rs
 +++ b/bindings/rust/build.rs
 @@ -15,24 +15,7 @@ fn main() {
@@ -27,7 +27,7 @@ index 692305a..e874ccd 100644
  
 -    let mut cc = cc::Build::new();
 -
--    #[cfg(windows)]
+-    #[cfg(all(windows, target_env = "msvc"))]
 -    {
 -        cc.flag("-D_CRT_SECURE_NO_WARNINGS");
 -
@@ -47,7 +47,7 @@ index 692305a..e874ccd 100644
  
      let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
      let bindings_out_path = out_dir.join("generated.rs");
-@@ -46,14 +29,12 @@ fn main() {
+@@ -46,7 +29,8 @@ fn main() {
      );
  
      // Finally, tell cargo this provides ckzg/ckzg_min
@@ -56,16 +56,7 @@ index 692305a..e874ccd 100644
 +    println!("cargo:rustc-link-arg=-l:rust_kzg_zkcrypto.a");
  }
  
--fn make_bindings<P>(
--    header_path: &str,
--    blst_headers_dir: &str,
--    bindings_out_path: P,
--) where
-+fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
-+where
-     P: AsRef<std::path::Path>,
- {
-     use bindgen::Builder;
+ fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
 -- 
 2.34.1
 


### PR DESCRIPTION
In this PR:
* Update `C_KZG_4844_GIT_HASH` to latest c-kzg-4844 commit ([`5115420`](https://github.com/ethereum/c-kzg-4844/tree/5115420ba3f919f5501155ba18633667001b6a07))
* Added support for nim bindings